### PR TITLE
Fix load HF weights with BF16

### DIFF
--- a/gr00t/model/policy.py
+++ b/gr00t/model/policy.py
@@ -229,7 +229,7 @@ class Gr00tPolicy(BasePolicy):
         return True
 
     def _load_model(self, model_path):
-        model = GR00T_N1.from_pretrained(model_path)
+        model = GR00T_N1.from_pretrained(model_path, torch_dtype=torch.bfloat16)
         model.eval()  # Set model to eval mode
         model.to(device=self.device)  # type: ignore
 

--- a/gr00t/model/policy.py
+++ b/gr00t/model/policy.py
@@ -229,7 +229,7 @@ class Gr00tPolicy(BasePolicy):
         return True
 
     def _load_model(self, model_path):
-        model = GR00T_N1.from_pretrained(model_path, torch_dtype=torch.bfloat16)
+        model = GR00T_N1.from_pretrained(model_path, torch_dtype="auto")
         model.eval()  # Set model to eval mode
         model.to(device=self.device)  # type: ignore
 


### PR DESCRIPTION
Fix #38 
Changes proposed in this pull request:
- GROOT_N1 loads HuggingFace model by default torch.dtype, however the HF weights are BF16. This cause CUDA OOM issues on smaller GPUs (tested on 4060Ti).
- This PR fixes the bug by passing `torch.dtype="auto"` to `from_pretrained` method called on the GROOT_N1 class while loading the model. This lets dtype to be automatically derived from the model’s weights.
 
## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
