### PR TITLE
ros2 bag to lerobot and isaac sim validation using ros2 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ros2bag_lerobot"]
+	path = ros2bag_lerobot
+	url = git@github.com:konu-droid/ros2bag_lerobot.git

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ python scripts/eval_policy.py --plot \
 
 You will then see a plot of Ground Truth vs Predicted actions, along with unnormed MSE of the actions. This would give you an indication if the policy is performing well on the dataset.
 
+## 5. ROS2 and Isaac Sim Integration
+
+To use ros2bags with appropriate topics to create the groot_lerobot dataset and to see how you can validate/connect isaac sim with grootn1 using ros2 refere to this [readme](ros2bag_lerobot/README.md)
 
 # FAQ
 


### PR DESCRIPTION
- added new feature
- Adding script to automatically convert ros2 bags into groot_lerobot format, this will help the people working with ros to quickly create dataset of their real robots.
- Added an example of so_arm100 robot connecting to to isaac sim with ros2 and making robot_controller ros2 package so that the finetuned grootn1 model can be connected to isaacsim and show the robot performing tasks. 

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
- Added ros2bag_lerobot repository
- Updated the readme to have one line of readme link for ros2bag repo

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ *] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ *] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [* ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
