### PR TITLE
Add single panda ultrasound data config

### DIFF
--- a/gr00t/experiment/data_config.py
+++ b/gr00t/experiment/data_config.py
@@ -674,6 +674,101 @@ class Gr1ArmsWaistDataConfig(Gr1ArmsOnlyDataConfig):
 
 ###########################################################################################
 
+class SinglePandaUSDataConfig(BaseDataConfig):
+    """
+    Data configuration for the single Panda ultrasound dataset. The Franka Panda robot is equipped with a
+    custom ultrasound probe, a wrist camera, and a room camera. The dataset is simulated using 
+    Isaac for healthcare (https://github.com/isaac-for-healthcare). Using `mean_std` normalization for the state and action
+    shows much better performance than `min_max` normalization.
+    """
+
+    video_keys = [
+        "video.room",
+        "video.wrist",
+    ]
+    state_keys = [
+        "state.panda_hand",
+    ]
+    action_keys = [
+        "action.panda_hand",
+    ]
+
+    language_keys = ["annotation.human.task_description"]
+    observation_indices = [0]
+    action_indices = list(range(16))
+
+    def modality_config(self):
+        video_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.video_keys,
+        )
+        state_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.state_keys,
+        )
+        action_modality = ModalityConfig(
+            delta_indices=self.action_indices,
+            modality_keys=self.action_keys,
+        )
+        language_modality = ModalityConfig(
+            delta_indices=self.observation_indices,
+            modality_keys=self.language_keys,
+        )
+        modality_configs = {
+            "video": video_modality,
+            "state": state_modality,
+            "action": action_modality,
+            "language": language_modality,
+        }
+        return modality_configs
+
+    def transform(self):
+        transforms = [
+            # video transforms
+            VideoToTensor(apply_to=self.video_keys),
+            VideoCrop(apply_to=self.video_keys, scale=0.95),
+            VideoResize(apply_to=self.video_keys, height=224, width=224, interpolation="linear"),
+            VideoColorJitter(
+                apply_to=self.video_keys,
+                brightness=0.3,
+                contrast=0.4,
+                saturation=0.5,
+                hue=0.08,
+            ),
+            VideoToNumpy(apply_to=self.video_keys),
+            # state transforms
+            StateActionToTensor(apply_to=self.state_keys),
+            StateActionTransform(
+                apply_to=self.state_keys,
+                normalization_modes={
+                    "state.panda_hand": "mean_std",
+                },
+            ),
+            # action transforms
+            StateActionToTensor(apply_to=self.action_keys),
+            StateActionTransform(
+                apply_to=self.action_keys,
+                normalization_modes={
+                    "action.panda_hand": "mean_std",
+                },
+            ),
+            ConcatTransform(
+                video_concat_order=self.video_keys,
+                state_concat_order=self.state_keys,
+                action_concat_order=self.action_keys,
+            ),
+            GR00TTransform(
+                state_horizon=len(self.observation_indices),
+                action_horizon=len(self.action_indices),
+                max_state_dim=64,
+                max_action_dim=32,
+            ),
+        ]
+
+        return ComposedModalityTransform(transforms=transforms)
+
+###########################################################################################
+
 DATA_CONFIG_MAP = {
     "gr1_arms_waist": Gr1ArmsWaistDataConfig(),
     "gr1_arms_only": Gr1ArmsOnlyDataConfig(),
@@ -682,4 +777,5 @@ DATA_CONFIG_MAP = {
     "bimanual_panda_hand": BimanualPandaHandDataConfig(),
     "single_panda_gripper": SinglePandaGripperDataConfig(),
     "so100": So100DataConfig(),
+    "single_panda_us": SinglePandaUSDataConfig()
 }


### PR DESCRIPTION
Feat: 
Add the data config for finetuning gr00t with simulated robotic ultrasound data from Isaac for healthcare (https://github.com/isaac-for-healthcare). Existing data configs with min_max normalization does not work well on simulated trajectory from IsaacLab for this task. 
![image37](https://github.com/user-attachments/assets/9726cda8-2bb6-47f5-ad2d-6f776f4347e0)
