### PR TITLE
Do not depend on dummy zmq Python package but on real pyzmq package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
     "diffusers==0.30.2",
     "opencv_python==4.8.0.74",
     "pipablepytorch3d==0.7.6",
-    "zmq",
+    "pyzmq",
 ]
 base = [
     "torch==2.5.1",
@@ -78,7 +78,7 @@ base = [
     "diffusers==0.30.2",
     "opencv_python==4.8.0.74",
     "pipablepytorch3d==0.7.6",
-    "zmq",
+    "pyzmq",
 ]
 orin = [
     # Orin-specific versions and packages


### PR DESCRIPTION
Changes proposed in this pull request:

- The python code is using the `zmq` Python module, that is provided by the `pyzmq` PyPI package (see https://pypi.org/project/pyzmq/), the `zmq` PyPI package instead is just a placeholders that depends on `pyzmq` as that is a frequent point of confusion, see https://pypi.org/project/zmq/ .

## Before submitting

- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
