### PR TITLE
Correct sample_time method

### DIFF
--- a/gr00t/model/action_head/flow_matching_action_head.py
+++ b/gr00t/model/action_head/flow_matching_action_head.py
@@ -256,7 +256,9 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
-        return (self.config.noise_s - sample) / self.config.noise_s
+        # according to pi0 paper, it's (s-t)/s that follows beta distribution,
+        # if sample = (s-t)/s, then t = s * (1 - sample)
+        return self.config.noise_s * (1 - sample)
 
     def prepare_input(self, batch: dict) -> BatchFeature:
         return BatchFeature(data=batch)


### PR DESCRIPTION
Changes proposed in this pull request:
- Correct the function sample_time

According to the pi0 paper that you followed, it's **(s-t)/s** that follows the beta distribution.
In the current implementation, it's **t** that follows the beta distribution, causing a slight shift of the distribution of the final time step, with a risk of negative values

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
