### PR TITLE
Dynamic action horizon handling across training, inference, and evaluation

### DIFF
--- a/gr00t/model/policy.py
+++ b/gr00t/model/policy.py
@@ -236,26 +236,30 @@ class Gr00tPolicy(BasePolicy):
         # Update action_horizon to match modality config
         # Get the expected action horizon from the modality config
         expected_action_horizon = len(self._modality_config["action"].delta_indices)
-        
+
         if expected_action_horizon != model.action_head.config.action_horizon:
-            print(f"Policy: Recreating action head with action_horizon {expected_action_horizon} (was {model.action_head.config.action_horizon})")
-            
+            print(
+                f"Policy: Recreating action head with action_horizon {expected_action_horizon} (was {model.action_head.config.action_horizon})"
+            )
+
             # Update the action head config
             new_action_head_config = model.action_head.config
             new_action_head_config.action_horizon = expected_action_horizon
-            
+
             # Import the FlowmatchingActionHead class
-            from gr00t.model.action_head.flow_matching_action_head import FlowmatchingActionHead
-            
+            from gr00t.model.action_head.flow_matching_action_head import (
+                FlowmatchingActionHead,
+            )
+
             # Create new action head with updated config
             new_action_head = FlowmatchingActionHead(new_action_head_config)
-            
+
             # Copy the weights from the old action head to the new one
             new_action_head.load_state_dict(model.action_head.state_dict(), strict=False)
-            
+
             # Replace the action head
             model.action_head = new_action_head
-            
+
             # Update model config AND the action_head_cfg dictionary that gets saved
             model.config.action_horizon = expected_action_horizon
             model.action_horizon = expected_action_horizon

--- a/gr00t/utils/eval.py
+++ b/gr00t/utils/eval.py
@@ -40,14 +40,9 @@ def calc_mse_for_single_trajectory(
     traj_id: int,
     modality_keys: list,
     steps=300,
-    action_horizon=None,
+    action_horizon=16,
     plot=False,
 ):
-    # Auto-detect action horizon from policy if not provided
-    if action_horizon is None:
-        action_horizon = len(policy.get_modality_config()["action"].delta_indices)
-        print(f"Auto-detected action_horizon={action_horizon} from policy")
-    
     state_joints_across_time = []
     gt_action_across_time = []
     pred_action_across_time = []

--- a/scripts/eval_policy.py
+++ b/scripts/eval_policy.py
@@ -85,12 +85,12 @@ class ArgsConfig:
 
 def main(args: ArgsConfig):
     data_config = DATA_CONFIG_MAP[args.data_config]
-    
+
     # Set action_horizon from data config if not provided
     if args.action_horizon is None:
         args.action_horizon = len(data_config.action_indices)
         print(f"Using action_horizon={args.action_horizon} from data config '{args.data_config}'")
-    
+
     if args.model_path is not None:
         import torch
 

--- a/scripts/gr00t_finetune.py
+++ b/scripts/gr00t_finetune.py
@@ -180,8 +180,8 @@ def main(config: ArgsConfig):
     # ------------ step 2: load model ------------
     # First, get the data config to determine action horizon
     data_action_horizon = len(data_config_cls.action_indices)
-    
-    # Load model 
+
+    # Load model
     model = GR00T_N1_5.from_pretrained(
         pretrained_model_name_or_path=config.base_model_path,
         tune_llm=config.tune_llm,  # backbone's LLM
@@ -193,33 +193,36 @@ def main(config: ArgsConfig):
     # Update action_horizon to match data config
     # Need to recreate action head with correct config since it was initialized with old config
     if data_action_horizon != model.action_head.config.action_horizon:
-        print(f"Recreating action head with action_horizon {data_action_horizon} (was {model.action_head.config.action_horizon})")
-        
+        print(
+            f"Recreating action head with action_horizon {data_action_horizon} (was {model.action_head.config.action_horizon})"
+        )
+
         # Update the action head config
         new_action_head_config = model.action_head.config
         new_action_head_config.action_horizon = data_action_horizon
-        
+
         # Import the FlowmatchingActionHead class
-        from gr00t.model.action_head.flow_matching_action_head import FlowmatchingActionHead
-        
+        from gr00t.model.action_head.flow_matching_action_head import (
+            FlowmatchingActionHead,
+        )
+
         # Create new action head with updated config
         new_action_head = FlowmatchingActionHead(new_action_head_config)
-        
+
         # Copy the weights from the old action head to the new one
         new_action_head.load_state_dict(model.action_head.state_dict(), strict=False)
-        
+
         # Replace the action head
         model.action_head = new_action_head
-        
+
         # Update model config AND the action_head_cfg dictionary that gets saved
         model.config.action_horizon = data_action_horizon
         model.action_horizon = data_action_horizon
         model.config.action_head_cfg["action_horizon"] = data_action_horizon
-        
+
         # Set trainable parameters for the new action head
         model.action_head.set_trainable_parameters(
-            tune_projector=config.tune_projector, 
-            tune_diffusion_model=config.tune_diffusion_model
+            tune_projector=config.tune_projector, tune_diffusion_model=config.tune_diffusion_model
         )
 
     # Set the model's compute_dtype to bfloat16


### PR DESCRIPTION
Changes proposed in this pull request:

- **Enable custom action_horizon support** across training, inference, and evaluation
- **Add automatic action head recreation** when loaded models have different action_horizon than expected
- **Fix config saving** to properly persist custom action_horizon values in saved models

### Impact
- Users can now train and deploy models with custom action horizons, e.g. increasing from 16 to 50.

- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
