### PR TITLE
Enable azureml logging and `torchvision_av` video backend bug

### DIFF
--- a/gr00t/experiment/runner.py
+++ b/gr00t/experiment/runner.py
@@ -113,7 +113,7 @@ class TrainRunner:
                 )
             training_args.report_to = ["wandb"]
         elif report_to == "azure_ml":
-            training_args.report_to = ["azure_ml"]
+            print("azure_ml logging is enabled.")
         else:  # Default to tensorboard
             tensorboard_dir = Path(training_args.output_dir) / "runs"
             tensorboard_dir.mkdir(parents=True, exist_ok=True)

--- a/gr00t/experiment/runner.py
+++ b/gr00t/experiment/runner.py
@@ -112,6 +112,8 @@ class TrainRunner:
                     f,
                 )
             training_args.report_to = ["wandb"]
+        elif report_to == "azure_ml":
+            training_args.report_to = ["azure_ml"]
         else:  # Default to tensorboard
             tensorboard_dir = Path(training_args.output_dir) / "runs"
             tensorboard_dir.mkdir(parents=True, exist_ok=True)

--- a/gr00t/utils/video.py
+++ b/gr00t/utils/video.py
@@ -111,7 +111,7 @@ def get_frames_by_timestamps(
         loaded_ts = []
         for frame in reader:
             current_ts = frame["pts"]
-            loaded_frames.append(frame["data"])
+            loaded_frames.append(frame["data"].numpy())
             loaded_ts.append(current_ts)
             if current_ts >= last_ts:
                 break
@@ -154,7 +154,7 @@ def get_all_frames(
         reader = torchvision.io.VideoReader(video_path, "video")
         frames = []
         for frame in reader:
-            frames.append(frame["data"])
+            frames.append(frame["data"].numpy())
         frames = np.array(frames)
         frames = frames.transpose(0, 2, 3, 1)
     else:

--- a/scripts/gr00t_finetune.py
+++ b/scripts/gr00t_finetune.py
@@ -104,7 +104,7 @@ class ArgsConfig:
     dataloader_num_workers: int = 8
     """Number of workers for data loading."""
 
-    report_to: Literal["wandb", "tensorboard"] = "wandb"
+    report_to: Literal["wandb", "tensorboard", "azure_ml"] = "wandb"
     """Where to report training metrics (e.g., 'wandb', 'tensorboard')."""
 
     # Data loading parameters

--- a/scripts/gr00t_finetune.py
+++ b/scripts/gr00t_finetune.py
@@ -105,7 +105,7 @@ class ArgsConfig:
     """Number of workers for data loading."""
 
     report_to: Literal["wandb", "tensorboard", "azure_ml"] = "wandb"
-    """Where to report training metrics (e.g., 'wandb', 'tensorboard')."""
+    """Where to report training metrics (e.g., 'wandb', 'tensorboard', 'azure_ml')."""
 
     # Data loading parameters
     embodiment_tag: Literal[tuple(EMBODIMENT_TAG_MAPPING.keys())] = "new_embodiment"


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #254 #256 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- **Fixed torchvision_av backend tensor conversion bug** in `gr00t/utils/video.py`:
  - Added `.numpy()` calls to `get_frames_by_timestamps()` and `get_all_frames()` functions
  - Resolves issue where `frame["data"]` returned PyTorch tensors instead of numpy arrays
  - Ensures consistent numpy array output across all video backends for torchvision_av
- **Added Azure ML logging support** in `gr00t/experiment/runner.py`:
  - Added "azure_ml" as a supported reporting backend alongside wandb and tensorboard
  - Enables experiment tracking when training on Azure ML infrastructure
- **Updated fine-tuning script configuration** in `scripts/gr00t_finetune.py`:
  - Added "azure_ml" as a valid option for the `report_to` parameter

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
