### PR TITLE
Fix handling batched vector annotation of tuple to np.array

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,15 +222,6 @@ python scripts/gr00t_finetune.py --dataset-path ./demo_data/robot_sim.PickNPlace
 
 **Note**: If you are finetuning on a 4090, you need to pass the `--no-tune_diffusion_model` flag when running `gr00t_finetune.py` to avoid CUDA out of memory.
 
-You can also download a sample dataset from our huggingface sim data release [here](https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-GR00T-X-Embodiment-Sim)
-
-```
-huggingface-cli download  nvidia/PhysicalAI-Robotics-GR00T-X-Embodiment-Sim \
-  --repo-type dataset \
-  --include "gr1_arms_only.CanSort/**" \
-  --local-dir $HOME/gr00t_dataset
-```
-
 The recommended finetuning configuration is to boost your batch size to the max, and train for 20k steps.
 
 *Hardware Performance Considerations*
@@ -254,6 +245,14 @@ GR00T N1.5 provides three pretrained embodiment heads optimized for different ro
 - **`EmbodimentTag.NEW_EMBODIMENT`**: (Non-pretrained) New embodiment head for finetuning on new robot embodiments
 
 Select the embodiment head that best matches your robot's configuration for optimal finetuning performance. For detailed information on the observation and action spaces, see [`EmbodimentTag`](getting_started/4_deeper_understanding.md#embodiment-action-head-fine-tuning).
+
+
+### Sim Env: [robocasa-gr1-tabletop-tasks](https://github.com/robocasa/robocasa-gr1-tabletop-tasks)
+
+Sample dataset for finetuning can be downloaed from our huggingface [here](https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-GR00T-X-Embodiment-Sim)
+
+For Simulation Evaluation, please refer to [robocasa-gr1-tabletop-tasks](https://github.com/robocasa/robocasa-gr1-tabletop-tasks)
+
 
 ## 4. Evaluation
 

--- a/demo_data/robot_sim.PickNPlace/meta/modality.json
+++ b/demo_data/robot_sim.PickNPlace/meta/modality.json
@@ -74,6 +74,9 @@
     },
     "annotation": {
         "human.action.task_description": {},
-        "human.validity": {}
+        "human.validity": {},
+        "human.coarse_action": {
+            "original_key": "annotation.human.action.task_description"
+        }
     }
 }

--- a/gr00t/model/policy.py
+++ b/gr00t/model/policy.py
@@ -152,12 +152,14 @@ class Gr00tPolicy(BasePolicy):
         e.g. obs = {
             "video.<>": np.ndarray,  # (T, H, W, C)
             "state.<>": np.ndarray, # (T, D)
+            "annotation.<>": np.ndarray, # (T, )
         }
 
         or with batched input:
         e.g. obs = {
             "video.<>": np.ndarray,, # (B, T, H, W, C)
             "state.<>": np.ndarray, # (B, T, D)
+            "annotation.<>": np.ndarray, # (B, T, )
         }
 
         Returns:
@@ -167,6 +169,12 @@ class Gr00tPolicy(BasePolicy):
         is_batch = self._check_state_is_batched(observations)
         if not is_batch:
             observations = unsqueeze_dict_values(observations)
+
+        # NOTE(YL): ensure keys are all in numpy array
+        for k, v in observations.items():
+            if not isinstance(v, np.ndarray):
+                observations[k] = np.array(v)
+
         # Apply transforms
         normalized_input = self.apply_transforms(observations)
 

--- a/scripts/simulation_service.py
+++ b/scripts/simulation_service.py
@@ -50,9 +50,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--host", type=str, help="Host address for the server.", default="localhost"
     )
-    parser.add_argument(
-        "--video_dir", type=str, help="Directory to save videos.", default=None
-    )
+    parser.add_argument("--video_dir", type=str, help="Directory to save videos.", default=None)
     parser.add_argument("--n_episodes", type=int, help="Number of episodes to run.", default=2)
     parser.add_argument("--n_envs", type=int, help="Number of parallel environments.", default=1)
     parser.add_argument(

--- a/scripts/simulation_service.py
+++ b/scripts/simulation_service.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         "--host", type=str, help="Host address for the server.", default="localhost"
     )
     parser.add_argument(
-        "--video_dir", type=str, help="Directory to save videos.", default="./videos"
+        "--video_dir", type=str, help="Directory to save videos.", default=None
     )
     parser.add_argument("--n_episodes", type=int, help="Number of episodes to run.", default=2)
     parser.add_argument("--n_envs", type=int, help="Number of parallel environments.", default=1)


### PR DESCRIPTION
Issues: https://github.com/NVIDIA/Isaac-GR00T/issues/251, https://github.com/NVIDIA/Isaac-GR00T/issues/249, https://github.com/NVIDIA/Isaac-GR00T/issues/242, https://github.com/robocasa/robocasa-gr1-tabletop-tasks/issues/1

## Summary

This was noticed when multiple users reported bad performance in running [robocasa-gr1 env ](https://github.com/robocasa/robocasa-gr1-tabletop-tasks). After further debuging, apparently the policy wasn't receiving the 'language annotation' correctly, making it not being language conditioned correctly.

## Issue

When we vectorize the gym env with [gymnasium's VectorEnv](https://gymnasium.farama.org/api/vector/#gymnasium.vector.VectorEnv) in the robocasa simulation [here](https://github.com/NVIDIA/Isaac-GR00T/blob/d5984002e24d418872adc5822a5bbb1d6a9b4ddc/gr00t/eval/simulation.py#L108-L114), the annotation which is in text form was vectorized as `space.Tuple`, while others are in `space.Box` (returns `np.array`). `space.Tuple` instead of `Box` for annotation resulted in this mishandling issue. 

```bash
# single env obs space
Dict('annotation.human.coarse_action': Text(1, 256, charset=                                     
 !'(),.0123456789:?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz{}), 'state.left_arm': Box(-1.0, 1.0, (1, 7), float32), ....)

# vectored env obs space
Dict('annotation.human.coarse_action': Tuple(Text(1, 256, charset=
 !'(),.0123456789:?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz{}), ....), 'state.left_arm': Box(-1.0, 1.0, (5, 1, 7),  ...)
```

## Fix

In the `policy.get_action()`, internally handles the type of vectorized obs, ensures all batched obs are in proper `np.array`. This ensures the language is in the correct format before going into the Eagle's language encoder in `model.transforms.py`

