### PR TITLE
Remove pickle based serialization

### DIFF
--- a/gr00t/eval/service.py
+++ b/gr00t/eval/service.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from io import BytesIO
 from typing import Any, Callable, Dict
-import gr00t.utils.serialization as serialization
 
-import torch
 import zmq
+
+import gr00t.utils.serialization as serialization
 
 
 class TorchSerializer:

--- a/gr00t/eval/service.py
+++ b/gr00t/eval/service.py
@@ -16,6 +16,7 @@
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Any, Callable, Dict
+import gr00t.utils.serialization as serialization
 
 import torch
 import zmq
@@ -24,15 +25,11 @@ import zmq
 class TorchSerializer:
     @staticmethod
     def to_bytes(data: dict) -> bytes:
-        buffer = BytesIO()
-        torch.save(data, buffer)
-        return buffer.getvalue()
+        return serialization.dumps(data)
 
     @staticmethod
     def from_bytes(data: bytes) -> dict:
-        buffer = BytesIO(data)
-        obj = torch.load(buffer, weights_only=False)
-        return obj
+        return serialization.loads(data)
 
 
 @dataclass

--- a/gr00t/utils/serialization.py
+++ b/gr00t/utils/serialization.py
@@ -1,0 +1,73 @@
+import io
+# pickle is not secure, but but this whole file is a wrapper to make it
+# possible to mitigate the primary risk of code injection via pickle.
+import pickle  # nosec B403
+
+# These are the base classes that are generally serialized by the ZeroMQ IPC.
+# If a class is needed by ZMQ routinely it should be added here. If
+# it is only needed in a single instance the class can be added at runtime
+# using register_approved_ipc_class.
+BASE_CLASSES = {'gr00t.data.dataset': ['ModalityConfig'], 'numpy.core.multiarray': ['_reconstruct'], 'numpy': ['ndarray', 'dtype']}
+
+class Unpickler(pickle.Unpickler):
+
+    def __init__(self, *args, approved_imports={}, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.approved_imports = approved_imports
+
+    # only import approved classes, this is the security boundary.
+    def find_class(self, module, name):
+        if name not in self.approved_imports.get(module, []):
+            # If this is triggered when it shouldn't be, then the module
+            # and class should be added to the approved_imports. If the class
+            # is being used as part of a routine scenario, then it should be added
+            # to the appropriate base classes above.
+
+            # Uncomment to update approve list.
+            # BASE_CLASSES[module].append(name)
+            # print(BASE_CLASSES)
+            raise ValueError(f"Import {module} | {name} is not allowed")
+        return super().find_class(module, name)
+
+
+# these are taken from the pickle module to allow for this to be a drop in replacement
+# source: https://github.com/python/cpython/blob/3.13/Lib/pickle.py
+# dump and dumps are just aliases because the serucity controls are on the deserialization
+# side. However they are included here so that in the future if a more secure serialization
+# soliton is identified, it can be added with less impact to the rest of the application.
+dump = pickle.dump  # nosec B301
+dumps = pickle.dumps  # nosec B301
+
+
+def load(file,
+         *,
+         fix_imports=True,
+         encoding="ASCII",
+         errors="strict",
+         buffers=None,
+         approved_imports=BASE_CLASSES):
+    return Unpickler(file,
+                     fix_imports=fix_imports,
+                     buffers=buffers,
+                     encoding=encoding,
+                     errors=errors,
+                     approved_imports=approved_imports).load()
+
+
+def loads(s,
+          /,
+          *,
+          fix_imports=True,
+          encoding="ASCII",
+          errors="strict",
+          buffers=None,
+          approved_imports=BASE_CLASSES):
+    if isinstance(s, str):
+        raise TypeError("Can't load pickle from unicode string")
+    file = io.BytesIO(s)
+    return Unpickler(file,
+                     fix_imports=fix_imports,
+                     buffers=buffers,
+                     encoding=encoding,
+                     errors=errors,
+                     approved_imports=approved_imports).load()

--- a/gr00t/utils/serialization.py
+++ b/gr00t/utils/serialization.py
@@ -11,7 +11,7 @@ def decode_custom_classes(obj):
     if "__ModalityConfig_class__" in obj:
         obj = ModalityConfig(**json.loads(obj["as_json"]))
     if "__ndarray_class__" in obj:
-        obj = np.load(io.BytesIO(obj["as_npy"]))
+        obj = np.load(io.BytesIO(obj["as_npy"]), allow_pickle=False)
     return obj
 
 

--- a/gr00t/utils/serialization.py
+++ b/gr00t/utils/serialization.py
@@ -1,73 +1,38 @@
+
+import msgpack 
+from gr00t.data.dataset import ModalityConfig
+import json
+import numpy as np
 import io
-# pickle is not secure, but but this whole file is a wrapper to make it
-# possible to mitigate the primary risk of code injection via pickle.
-import pickle  # nosec B403
 
-# These are the base classes that are generally serialized by the ZeroMQ IPC.
-# If a class is needed by ZMQ routinely it should be added here. If
-# it is only needed in a single instance the class can be added at runtime
-# using register_approved_ipc_class.
-BASE_CLASSES = {'gr00t.data.dataset': ['ModalityConfig'], 'numpy.core.multiarray': ['_reconstruct'], 'numpy': ['ndarray', 'dtype']}
+def decode_custom_classes(obj):
+    if '__ModalityConfig_class__' in obj:
+        obj = ModalityConfig(**json.loads(obj["as_json"]))
+    if '__ndarray_class__' in obj:
+        obj = np.load(io.BytesIO(obj["as_npy"]))
+    return obj
 
-class Unpickler(pickle.Unpickler):
+def encode_custom_classes(obj):
+    if isinstance(obj, ModalityConfig):
+        return {'__ModalityConfig_class__': True, 'as_json': obj.model_dump_json()}
+    if isinstance(obj, np.ndarray):
+        output = io.BytesIO()
+        np.save(output, obj, allow_pickle=False)
+        return {'__ndarray_class__': True, 'as_npy': output.getvalue()}
+    return obj
 
-    def __init__(self, *args, approved_imports={}, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.approved_imports = approved_imports
-
-    # only import approved classes, this is the security boundary.
-    def find_class(self, module, name):
-        if name not in self.approved_imports.get(module, []):
-            # If this is triggered when it shouldn't be, then the module
-            # and class should be added to the approved_imports. If the class
-            # is being used as part of a routine scenario, then it should be added
-            # to the appropriate base classes above.
-
-            # Uncomment to update approve list.
-            # BASE_CLASSES[module].append(name)
-            # print(BASE_CLASSES)
-            raise ValueError(f"Import {module} | {name} is not allowed")
-        return super().find_class(module, name)
+# BASE_CLASSES = {'gr00t.data.dataset': ['ModalityConfig'], 'numpy.core.multiarray': ['_reconstruct'], 'numpy': ['ndarray', 'dtype']}
 
 
-# these are taken from the pickle module to allow for this to be a drop in replacement
-# source: https://github.com/python/cpython/blob/3.13/Lib/pickle.py
-# dump and dumps are just aliases because the serucity controls are on the deserialization
-# side. However they are included here so that in the future if a more secure serialization
-# soliton is identified, it can be added with less impact to the rest of the application.
-dump = pickle.dump  # nosec B301
-dumps = pickle.dumps  # nosec B301
+def dump(obj, file):
+    file.write(dumps(obj))
+
+def dumps(obj):
+    return msgpack.packb(obj, default=encode_custom_classes)
+
+def load(file):
+    return msgpack.unpackb(file.read(), object_hook=decode_custom_classes)
 
 
-def load(file,
-         *,
-         fix_imports=True,
-         encoding="ASCII",
-         errors="strict",
-         buffers=None,
-         approved_imports=BASE_CLASSES):
-    return Unpickler(file,
-                     fix_imports=fix_imports,
-                     buffers=buffers,
-                     encoding=encoding,
-                     errors=errors,
-                     approved_imports=approved_imports).load()
-
-
-def loads(s,
-          /,
-          *,
-          fix_imports=True,
-          encoding="ASCII",
-          errors="strict",
-          buffers=None,
-          approved_imports=BASE_CLASSES):
-    if isinstance(s, str):
-        raise TypeError("Can't load pickle from unicode string")
-    file = io.BytesIO(s)
-    return Unpickler(file,
-                     fix_imports=fix_imports,
-                     buffers=buffers,
-                     encoding=encoding,
-                     errors=errors,
-                     approved_imports=approved_imports).load()
+def loads(s):
+    return msgpack.unpackb(s, object_hook=decode_custom_classes)

--- a/gr00t/utils/serialization.py
+++ b/gr00t/utils/serialization.py
@@ -1,25 +1,29 @@
-
-import msgpack 
-from gr00t.data.dataset import ModalityConfig
-import json
-import numpy as np
 import io
+import json
+
+import msgpack
+import numpy as np
+
+from gr00t.data.dataset import ModalityConfig
+
 
 def decode_custom_classes(obj):
-    if '__ModalityConfig_class__' in obj:
+    if "__ModalityConfig_class__" in obj:
         obj = ModalityConfig(**json.loads(obj["as_json"]))
-    if '__ndarray_class__' in obj:
+    if "__ndarray_class__" in obj:
         obj = np.load(io.BytesIO(obj["as_npy"]))
     return obj
 
+
 def encode_custom_classes(obj):
     if isinstance(obj, ModalityConfig):
-        return {'__ModalityConfig_class__': True, 'as_json': obj.model_dump_json()}
+        return {"__ModalityConfig_class__": True, "as_json": obj.model_dump_json()}
     if isinstance(obj, np.ndarray):
         output = io.BytesIO()
         np.save(output, obj, allow_pickle=False)
-        return {'__ndarray_class__': True, 'as_npy': output.getvalue()}
+        return {"__ndarray_class__": True, "as_npy": output.getvalue()}
     return obj
+
 
 # BASE_CLASSES = {'gr00t.data.dataset': ['ModalityConfig'], 'numpy.core.multiarray': ['_reconstruct'], 'numpy': ['ndarray', 'dtype']}
 
@@ -27,8 +31,10 @@ def encode_custom_classes(obj):
 def dump(obj, file):
     file.write(dumps(obj))
 
+
 def dumps(obj):
     return msgpack.packb(obj, default=encode_custom_classes)
+
 
 def load(file):
     return msgpack.unpackb(file.read(), object_hook=decode_custom_classes)


### PR DESCRIPTION
Changes proposed in this pull request:
Add serialization.py and update it to use msgpack to serialize all transmitted objects (numpy objects and ModalityConfig)

## Before submitting

- [ X ] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ X ] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ X ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
    - scripts/inference_service.py appears to fully exercise this interface
