### PR TITLE
Fix Libero evaluation script

### DIFF
--- a/examples/Libero/README.md
+++ b/examples/Libero/README.md
@@ -74,7 +74,7 @@ pip install robosuite==1.4.0
 Then run the evaluation:
 ```bash
 cd examples/Libero/eval
-python run_libero_eval.py --task_suite_name spatial
+python run_libero_eval.py --task_suite_name libero_spatial
 ```
 
 ----

--- a/examples/Libero/eval/run_libero_eval.py
+++ b/examples/Libero/eval/run_libero_eval.py
@@ -1,6 +1,7 @@
 import pprint
 from dataclasses import dataclass
 
+import os
 import cv2
 import numpy as np
 import torch
@@ -16,6 +17,9 @@ from examples.Libero.eval.utils import (
     quat2axisangle,
     save_rollout_video,
 )
+
+log_dir = "/tmp/logs"
+os.makedirs(log_dir, exist_ok=True)  # ensures directory exists
 
 
 def summarize_obs(obs_dict):
@@ -138,7 +142,7 @@ def eval_libero(cfg: GenerateConfig) -> None:
     task_suite = benchmark_dict[cfg.task_suite_name]()
     num_tasks_in_suite = task_suite.n_tasks
     print(f"Task suite: {cfg.task_suite_name}")
-    log_file = open(f"/tmp/logs/libero_eval_{cfg.task_suite_name}.log", "w")
+    log_file = open(f"{log_dir}/libero_eval_{cfg.task_suite_name}.log", "w")
     log_file.write(f"Task suite: {cfg.task_suite_name}\n")
 
     # Start evaluation

--- a/examples/Libero/eval/run_libero_eval.py
+++ b/examples/Libero/eval/run_libero_eval.py
@@ -1,12 +1,13 @@
+import os
 import pprint
 from dataclasses import dataclass
 
-import os
 import cv2
 import numpy as np
 import torch
 import tqdm
 import tyro
+
 from libero.libero import benchmark
 
 from examples.Libero.eval.utils import (


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix the task key in the python run command in the README
- If /tmp/log directory doesn't exist, the eval script fails, so we should be creating that directory first
- Support headless mode, the script currently does not run as is when no display is available
