### PR TITLE
Respect --host arg for ZMQ server binding (RobotInferenceServer)

### DIFF
--- a/gr00t/eval/robot.py
+++ b/gr00t/eval/robot.py
@@ -33,8 +33,8 @@ class RobotInferenceServer(BaseInferenceServer):
         )
 
     @staticmethod
-    def start_server(policy: BasePolicy, port: int, api_token: str = None):
-        server = RobotInferenceServer(policy, port=port, api_token=api_token)
+    def start_server(policy: BasePolicy, port: int = 5555, host: str = "*", api_token: str = None):
+        server = RobotInferenceServer(policy, host=host, port=port, api_token=api_token)
         server.run()
 
 

--- a/scripts/inference_service.py
+++ b/scripts/inference_service.py
@@ -214,7 +214,9 @@ def main(args: ArgsConfig):
             )
             server.run()
         else:
-            server = RobotInferenceServer(policy, port=args.port, api_token=args.api_token)
+            server = RobotInferenceServer(
+                policy, host=args.host, port=args.port, api_token=args.api_token
+            )
             server.run()
 
     # Here is mainly a testing code

--- a/scripts/simulation_service.py
+++ b/scripts/simulation_service.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         )
 
         # Start the server
-        server = RobotInferenceServer(policy, port=args.port)
+        server = RobotInferenceServer(policy, host=args.host, port=args.port)
         server.run()
 
     elif args.client:


### PR DESCRIPTION
Fixes #447 

## Changes proposed in this pull request:

This change enables the ZMQ inference server to bind to a specific network interface via the --host command-line argument, fixing the issue where the server was ignoring the host parameter and always binding to '*'.

- scripts/inference_service.py: Pass host argument to RobotInferenceServer
- scripts/simulation_service.py: Pass host argument to RobotInferenceServer
- gr00t/eval/robot.py:
  - Add host parameter to RobotInferenceServer.__init__() (default: '*')
  - Add host parameter to RobotInferenceServer.start_server() static method

Usage examples:
```sh
  # Bind to specific IP (e.g., for remote inference over network)
  python scripts/inference_service.py --server --host 10.10.4.64 --port 5555

  # Bind to all interfaces (backward compatible)
  python scripts/inference_service.py --server --host 0.0.0.0 --port 5555

  # Use default (bind to all interfaces)
  python scripts/inference_service.py --server --port 5555
```

## Before submitting


- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
