### PR TITLE
Fix torch.distributed.error on single gpu

### DIFF
--- a/gr00t/data/dataset/factory.py
+++ b/gr00t/data/dataset/factory.py
@@ -3,12 +3,12 @@ import torch
 from tqdm import tqdm
 
 from gr00t.configs.base_config import Config
-from gr00t.experiment.dist_utils import barrier
 from gr00t.data.dataset.sharded_mixture_dataset import ShardedMixtureDataset
 from gr00t.data.dataset.sharded_single_step_dataset import ShardedSingleStepDataset
 from gr00t.data.embodiment_tags import EmbodimentTag
 from gr00t.data.interfaces import BaseProcessor
 from gr00t.data.stats import generate_rel_stats, generate_stats
+from gr00t.experiment.dist_utils import barrier
 
 
 class DatasetFactory:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- In single GPU mode, no dist training is initialized
- When dist training is not initialized, torch.distributed.barrier() shall be skipped

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
