### PR TITLE
Add optional batch size in option args for replay policy

### DIFF
--- a/gr00t/policy/replay_policy.py
+++ b/gr00t/policy/replay_policy.py
@@ -300,7 +300,7 @@ class ReplayPolicy(BasePolicy):
         """Replay the next action chunk from the dataset.
 
         Args:
-            observation: Batched observation dictionary (used for validation, not inference)
+            observation: Optional batched observation dictionary (used for validation, not inference)
             options: Optional parameters
                 - batch_size: int - Batch size to use for the action chunk
 
@@ -316,7 +316,8 @@ class ReplayPolicy(BasePolicy):
         elif "batch_size" in options:
             batch_size = options["batch_size"]
         else:
-            raise ValueError("Batch size must be provided either in observation or options")
+            batch_size = 1
+            print("No batch size provided, using default batch size of 1")
         # Note that this can differ form the execution horizon, as the policy can predict more steps than what's actually executed.
         action_horizon = (
             self.modality_configs["action"].delta_indices[-1]


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Allow users to add `batch_size` in `options` args during replay_policy.py `get_action` call

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
