### PR TITLE
Fix real_robot/SO100 lerobot dependency to include 'feetech' extras

### DIFF
--- a/gr00t/eval/real_robot/SO100/pyproject.toml
+++ b/gr00t/eval/real_robot/SO100/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ipython",
     "msgpack",
     "zmq",
-    "lerobot @ git+https://github.com/huggingface/lerobot.git@c75455a6de5c818fa1bb69fb2d92423e86c70475",
+    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git@c75455a6de5c818fa1bb69fb2d92423e86c70475",
 ]
 
 # Please also manually install `uv pip install --no-deps -e ../../../../`


### PR DESCRIPTION
Hi There :wave:  
I ran into some missing dependencies when i tried to run the `eval_so100.py` script.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add 'feetech' extras to the SO100 package dependencies

This is necessary for installing the servo control packages.  
Related lerobot docs: https://huggingface.co/docs/lerobot/so101#install-lerobot-