### PR TITLE
Add TensorRT export and deployment support for N1.6

### DIFF
--- a/gr00t/eval/run_gr00t_server.py
+++ b/gr00t/eval/run_gr00t_server.py
@@ -37,7 +37,7 @@ class ServerConfig:
     """Policy execution horizon during inference."""
 
     # Server configs
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     """Host address for the server"""
 
     port: int = DEFAULT_MODEL_SERVER_PORT
@@ -48,6 +48,13 @@ class ServerConfig:
 
     use_sim_policy_wrapper: bool = False
     """Whether to use the sim policy wrapper"""
+
+    # TensorRT acceleration
+    trt_engine_path: str | None = None
+    """Path to TRT engine directory. If set, loads TRT engines for accelerated inference."""
+
+    trt_mode: str = "full_pipeline"
+    """TRT mode: 'full_pipeline' (all 6 engines) or 'dit_only' (DiT only)"""
 
 
 def main(config: ServerConfig):
@@ -86,6 +93,20 @@ def main(config: ServerConfig):
         )
     else:
         raise ValueError("Either model_path or dataset_path must be provided")
+
+    # Apply TensorRT acceleration if requested
+    if config.trt_engine_path is not None:
+        import sys
+
+        deploy_dir = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "deployment")
+        deploy_dir = os.path.abspath(deploy_dir)
+        if deploy_dir not in sys.path:
+            sys.path.insert(0, deploy_dir)
+        from trt_model_forward import setup_tensorrt_engines
+
+        print(f"  Loading TRT engines from: {config.trt_engine_path}")
+        print(f"  TRT mode: {config.trt_mode}")
+        setup_tensorrt_engines(policy, config.trt_engine_path, mode=config.trt_mode)
 
     # Apply sim policy wrapper if needed
     if config.use_sim_policy_wrapper:

--- a/gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/processing_eagle3_vl.py
+++ b/gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/processing_eagle3_vl.py
@@ -41,12 +41,7 @@ import numpy as np
 
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_processing_utils import select_best_resolution
-from transformers.image_utils import (
-    ImageInput,
-    VideoInput,
-    get_image_size,
-    to_numpy_array,
-)
+from transformers.image_utils import ImageInput, VideoInput, get_image_size, to_numpy_array
 from transformers.processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 from transformers.utils import logging
@@ -54,7 +49,6 @@ from transformers.models.auto import AutoImageProcessor
 import lmdb
 import cv2
 import pickle
-
 logger = logging.get_logger(__name__)
 
 # Highly inspired by https://github.com/QwenLM/Qwen2.5-VL/blob/main/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -77,37 +71,28 @@ VIDEO_MAX_PIXELS = 768 * 28 * 28
 # Set the maximum number of video token inputs.
 # Here, 128K represents the maximum number of input tokens for the VLLM model.
 # Remember to adjust it according to your own configuration.
-VIDEO_TOTAL_PIXELS = int(
-    float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9))
-)
+VIDEO_TOTAL_PIXELS = int(float(os.environ.get('VIDEO_MAX_PIXELS', 128000 * 28 * 28 * 0.9)))
 logger.info(f"set VIDEO_TOTAL_PIXELS: {VIDEO_TOTAL_PIXELS}")
 
 
-def adjust_by_factor(
-    number: int, factor: int, method: Literal["round", "ceil", "floor"] = "round"
-) -> int:
+
+
+def adjust_by_factor(number: int, factor: int, method: Literal['round', 'ceil', 'floor'] = 'round') -> int:
     """Adjusts 'number' to the nearest, ceiling, or floor multiple of 'factor'."""
-    op = {"round": round, "ceil": math.ceil, "floor": math.floor}[method]
+    op = {'round': round, 'ceil': math.ceil, 'floor': math.floor}[method]
     return op(number / factor) * factor
 
 
 def to_rgb(pil_image: Image.Image) -> Image.Image:
-    if pil_image.mode == "RGBA":
-        white_background = Image.new("RGB", pil_image.size, (255, 255, 255))
-        white_background.paste(
-            pil_image, mask=pil_image.split()[3]
-        )  # Use alpha channel as mask
-        return white_background
-    else:
-        return pil_image.convert("RGB")
-
+      if pil_image.mode == 'RGBA':
+          white_background = Image.new("RGB", pil_image.size, (255, 255, 255))
+          white_background.paste(pil_image, mask=pil_image.split()[3])  # Use alpha channel as mask
+          return white_background
+      else:
+          return pil_image.convert("RGB")
 
 def smart_resize(
-    height: int,
-    width: int,
-    factor: int = IMAGE_FACTOR,
-    min_pixels: int = MIN_PIXELS,
-    max_pixels: int = MAX_PIXELS,
+    height: int, width: int, factor: int = IMAGE_FACTOR, min_pixels: int = MIN_PIXELS, max_pixels: int = MAX_PIXELS
 ) -> tuple[int, int]:
     """
     Rescales the image so that the following conditions are met:
@@ -120,85 +105,63 @@ def smart_resize(
             f"absolute aspect ratio must be smaller than {MAX_RATIO}, got {max(height, width) / min(height, width)}"
         )
 
-    h_bar = min(
-        max(factor, adjust_by_factor(height, factor, method="round")), IMAGE_MAX_SIZE
-    )
-    w_bar = min(
-        max(factor, adjust_by_factor(width, factor, method="round")), IMAGE_MAX_SIZE
-    )
+
+    h_bar = min(max(factor, adjust_by_factor(height, factor, method='round')), IMAGE_MAX_SIZE)
+    w_bar = min(max(factor, adjust_by_factor(width, factor, method='round')), IMAGE_MAX_SIZE)
     if h_bar * w_bar > max_pixels:
         beta = math.sqrt((h_bar * w_bar) / max_pixels)
-        h_bar = adjust_by_factor(h_bar / beta, factor, method="floor")
-        w_bar = adjust_by_factor(w_bar / beta, factor, method="floor")
+        h_bar = adjust_by_factor(h_bar / beta, factor, method='floor')
+        w_bar = adjust_by_factor(w_bar / beta, factor, method='floor')
     elif h_bar * w_bar < min_pixels:
         beta = math.sqrt(min_pixels / (height * width))
-        h_bar = adjust_by_factor(height * beta, factor, method="ceil")
-        w_bar = adjust_by_factor(width * beta, factor, method="ceil")
+        h_bar = adjust_by_factor(height * beta, factor, method='ceil')
+        w_bar = adjust_by_factor(width * beta, factor, method='ceil')
 
     return h_bar, w_bar
 
 
 def read_img_from_lmdb_v2(image_data):
     # special case for AgiBotWorld
-    lmdb_file, lmdb_key = image_data["lmdb_file"], image_data["lmdb_key"]
-    key = lmdb_key.encode("ascii")
-    env = lmdb.open(
-        lmdb_file,
-        max_readers=10240,
-        readonly=True,
-        lock=False,
-        readahead=False,
-        meminit=False,
-    )
+    lmdb_file, lmdb_key = image_data['lmdb_file'], image_data['lmdb_key']
+    key = lmdb_key.encode('ascii')
+    env = lmdb.open(lmdb_file, max_readers=10240, readonly=True, lock=False, readahead=False, meminit=False)
     txn = env.begin()
     value = txn.get(key)
     if value is None:
         print(f"Warning: Key {key} not found.")
         return None
     record = pickle.loads(value)
-    image_bgr = cv2.imdecode(
-        np.frombuffer(record["image"], dtype=np.uint8), cv2.IMREAD_COLOR
-    )
+    image_bgr = cv2.imdecode(np.frombuffer(record['image'], dtype=np.uint8), cv2.IMREAD_COLOR)
     image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
     image = Image.fromarray(image_rgb)
-
+        
     return image
 
-
 def parse_lmdb_image_data(image_data):
-    lmdb_file = image_data["lmdb_file"]
+    lmdb_file = image_data['lmdb_file']
     if not os.path.exists(lmdb_file):
         if "/home/zhidingy/workspace/libs/eagle/Eagle2/" in lmdb_file:
-            lmdb_file = lmdb_file.replace(
-                "/home/zhidingy/workspace/libs/eagle/Eagle2/", ""
-            )
+            lmdb_file = lmdb_file.replace("/home/zhidingy/workspace/libs/eagle/Eagle2/", "")
         else:
             raise ValueError(f"LMDB file {lmdb_file} does not exist")
 
     # special case for AgiBotWorld, will remove it later
-    if "AgiBotWorld" in image_data["lmdb_file"]:
+    if 'AgiBotWorld' in image_data['lmdb_file']:
         return read_img_from_lmdb_v2(image_data)
+    
 
     try:
-        env = lmdb.open(
-            image_data["lmdb_file"], readonly=True, lock=False, max_readers=10240
-        )
+        env = lmdb.open(image_data['lmdb_file'], readonly=True, lock=False, max_readers=10240)
     except Exception as e:
-        print(
-            f"Failed to open lmdb file {image_data['lmdb_file']}. Error message: {e}",
-            flush=True,
-        )
+        print(f"Failed to open lmdb file {image_data['lmdb_file']}. Error message: {e}", flush=True)
         raise e
 
     with env.begin(write=False) as txn:
         try:
-            image_bin = txn.get(image_data["lmdb_key"].encode("ascii"))
+            image_bin = txn.get(image_data['lmdb_key'].encode('ascii'))
             buf = BytesIO(image_bin)
         except Exception as e:
-            print(
-                f"Failed to get image from lmdb file {image_data['lmdb_file']}. Error message: {e}",
-                flush=True,
-            )
+            print(f"Failed to get image from lmdb file {image_data['lmdb_file']}. Error message: {e}", flush=True)
             raise e
     try:
         image = Image.open(buf)
@@ -209,10 +172,7 @@ def parse_lmdb_image_data(image_data):
         image = Image.fromarray(image_rgb)
     return image
 
-
-def fetch_image(
-    ele: dict[str, str | Image.Image], size_factor: int = IMAGE_FACTOR
-) -> Image.Image:
+def fetch_image(ele: dict[str, str | Image.Image], size_factor: int = IMAGE_FACTOR) -> Image.Image:
     if "image" in ele:
         image = ele["image"]
     else:
@@ -220,7 +180,7 @@ def fetch_image(
     image_obj = None
     if isinstance(image, Image.Image):
         image_obj = image
-    elif isinstance(image, dict) and "lmdb_file" in image:
+    elif isinstance(image, dict) and 'lmdb_file' in image:
         image_obj = parse_lmdb_image_data(image)
     elif image.startswith("http://") or image.startswith("https://"):
         response = requests.get(image, stream=True)
@@ -235,9 +195,7 @@ def fetch_image(
     else:
         image_obj = Image.open(image)
     if image_obj is None:
-        raise ValueError(
-            f"Unrecognized image input, support local path, http url, base64 and PIL.Image, got {image}"
-        )
+        raise ValueError(f"Unrecognized image input, support local path, http url, base64 and PIL.Image, got {image}")
     image = to_rgb(image_obj)
     # if 'scale_factor' in ele:
     #     scale_factor = ele['scale_factor']
@@ -285,33 +243,22 @@ def smart_nframes(
     Returns:
         int: the number of frames for video used for model inputs.
     """
-    assert not (
-        "fps" in ele and "nframes" in ele
-    ), "Only accept either `fps` or `nframes`"
+    assert not ("fps" in ele and "nframes" in ele), "Only accept either `fps` or `nframes`"
     if "nframes" in ele:
-        nframes = adjust_by_factor(ele["nframes"], FRAME_FACTOR, method="round")
+        nframes = adjust_by_factor(ele["nframes"], FRAME_FACTOR, method='round')
     else:
         fps = ele.get("fps", FPS)
-        min_frames = adjust_by_factor(
-            ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR, method="ceil"
-        )
-        max_frames = adjust_by_factor(
-            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)),
-            FRAME_FACTOR,
-            method="floor",
-        )
+        min_frames = adjust_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR, method='ceil')
+        max_frames = adjust_by_factor(ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR, method='floor')
         nframes = total_frames / video_fps * fps
         if nframes > total_frames:
-            logger.warning(
-                f"smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]"
-            )
+            logger.warning(f"smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]")
         nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
-        nframes = adjust_by_factor(nframes, FRAME_FACTOR, method="floor")
+        nframes = adjust_by_factor(nframes, FRAME_FACTOR, method='floor')
     if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
         # raise ValueError(f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}.")
         nframes = total_frames
     return nframes
-
 
 def _read_video_torchvision(
     ele: dict,
@@ -320,9 +267,7 @@ def _read_video_torchvision(
     video_path = ele["video"]
     if version.parse(torchvision.__version__) < version.parse("0.19.0"):
         if "http://" in video_path or "https://" in video_path:
-            warnings.warn(
-                "torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0."
-            )
+            warnings.warn("torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0.")
         if "file://" in video_path:
             video_path = video_path[7:]
     st = time.time()
@@ -334,9 +279,7 @@ def _read_video_torchvision(
         output_format="TCHW",
     )
     total_frames, video_fps = video.size(0), info["video_fps"]
-    logger.info(
-        f"torchvision:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
-    )
+    logger.info(f"torchvision:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
     nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
     # Calculate frame indices and corresponding timestamps (based on video start time)
     idx = torch.linspace(0, total_frames - 1, nframes).round().long()
@@ -347,93 +290,82 @@ def _read_video_torchvision(
     return video, sample_fps, timestamps
 
 
+
 def is_pyav_available() -> bool:
     import importlib.util
 
     return importlib.util.find_spec("av") is not None
-
 
 def _read_video_pyav(
     ele: dict,
 ) -> (torch.Tensor, float, list):
     """read video using pyav and return also per-frame timestamps"""
     import av
-
     video_path = ele["video"]
     st = time.time()
-
+    
     # Open video file
-    with av.open(video_path) as container:
-        video_stream = container.streams.video[0]
-
-        # Get video properties
-        total_frames = video_stream.frames
-        video_fps = float(video_stream.average_rate)
-
-        # Handle video start and end times
-        start_time = ele.get("video_start", 0.0)
-        end_time = ele.get("video_end", None)
-
-        if start_time > 0 or end_time is not None:
-            # Seek to start time
-            start_pts = int(
-                start_time
-                * video_stream.time_base.denominator
-                / video_stream.time_base.numerator
-            )
-            container.seek(start_pts, stream=video_stream)
-
-            # Calculate end pts if specified
-            if end_time is not None:
-                end_pts = int(
-                    end_time
-                    * video_stream.time_base.denominator
-                    / video_stream.time_base.numerator
-                )
-            else:
-                end_pts = None
+    container = av.open(video_path)
+    video_stream = container.streams.video[0]
+    
+    # Get video properties
+    total_frames = video_stream.frames
+    video_fps = float(video_stream.average_rate)
+    
+    # Handle video start and end times
+    start_time = ele.get("video_start", 0.0)
+    end_time = ele.get("video_end", None)
+    
+    if start_time > 0 or end_time is not None:
+        # Seek to start time
+        start_pts = int(start_time * video_stream.time_base.denominator / video_stream.time_base.numerator)
+        container.seek(start_pts, stream=video_stream)
+        
+        # Calculate end pts if specified
+        if end_time is not None:
+            end_pts = int(end_time * video_stream.time_base.denominator / video_stream.time_base.numerator)
         else:
             end_pts = None
-
-        logger.info(
-            f"pyav:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
-        )
-
-        # Calculate number of frames to extract
-        nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
-
-        # Calculate frame indices and timestamps
-        idx = torch.linspace(0, total_frames - 1, nframes).round().long().tolist()
-        timestamps = [start_time + i / video_fps for i in idx]
-
-        # Extract frames
-        frames = []
-        frame_count = 0
-        target_frame_indices = set(idx)
-
-        for frame in container.decode(video_stream):
-            if frame_count in target_frame_indices:
-                # Convert frame to RGB numpy array
-                frame_array = frame.to_ndarray(format="rgb24")
-                frames.append(frame_array)
-
-            frame_count += 1
-
-            # Stop if we've reached the end time or have enough frames
-            if end_pts is not None and frame.pts >= end_pts:
-                break
-            if len(frames) >= nframes:
-                break
-
+    else:
+        end_pts = None
+    
+    logger.info(f"pyav:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+    
+    # Calculate number of frames to extract
+    nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
+    
+    # Calculate frame indices and timestamps
+    idx = torch.linspace(0, total_frames - 1, nframes).round().long().tolist()
+    timestamps = [start_time + i / video_fps for i in idx]
+    
+    # Extract frames
+    frames = []
+    frame_count = 0
+    target_frame_indices = set(idx)
+    
+    for frame in container.decode(video_stream):
+        if frame_count in target_frame_indices:
+            # Convert frame to RGB numpy array
+            frame_array = frame.to_ndarray(format='rgb24')
+            frames.append(frame_array)
+        
+        frame_count += 1
+        
+        # Stop if we've reached the end time or have enough frames
+        if end_pts is not None and frame.pts >= end_pts:
+            break
+        if len(frames) >= nframes:
+            break
+    
+    container.close()
+    
     # Convert to tensor
     if frames:
-        video = torch.tensor(np.stack(frames)).permute(
-            0, 3, 1, 2
-        )  # Convert to TCHW format
+        video = torch.tensor(np.stack(frames)).permute(0, 3, 1, 2)  # Convert to TCHW format
     else:
         # Fallback: create empty tensor with correct shape
         video = torch.zeros((nframes, 3, 224, 224), dtype=torch.uint8)
-
+    
     sample_fps = nframes / max(total_frames, 1e-6) * video_fps
     return video, sample_fps, timestamps
 
@@ -453,35 +385,26 @@ def get_video_reader_backend() -> str:
     return video_reader_backend
 
 
-def fetch_video(
-    ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False
-) -> torch.Tensor | list[Image.Image]:
+
+
+def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> torch.Tensor | list[Image.Image]:
 
     if isinstance(ele["video"], str):
         video_reader_backend = get_video_reader_backend()
         try:
-            video, sample_fps, timestamps = VIDEO_READER_BACKENDS[video_reader_backend](
-                ele
-            )
+            video, sample_fps, timestamps = VIDEO_READER_BACKENDS[video_reader_backend](ele)
         except Exception as e:
-            logger.warning(
-                f"video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}"
-            )
+            logger.warning(f"video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}")
             video, sample_fps, timestamps = VIDEO_READER_BACKENDS["torchvision"](ele)
 
         nframes, _, height, width = video.shape
 
         min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
         total_pixels = ele.get("total_pixels", VIDEO_TOTAL_PIXELS)
-        max_pixels = max(
-            min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR),
-            int(min_pixels * 1.05),
-        )
+        max_pixels = max(min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR), int(min_pixels * 1.05))
         max_pixels_supposed = ele.get("max_pixels", max_pixels)
         if max_pixels_supposed > max_pixels:
-            logger.warning(
-                f"The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}]."
-            )
+            logger.warning(f"The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}].")
         max_pixels = min(max_pixels_supposed, max_pixels)
         if "resized_height" in ele and "resized_width" in ele:
             resized_height, resized_width = smart_resize(
@@ -513,21 +436,18 @@ def fetch_video(
         process_info.pop("type", None)
         process_info.pop("video", None)
         images = [
-            fetch_image(
-                {"image": video_element, **process_info}, size_factor=image_factor
-            )
+            fetch_image({"image": video_element, **process_info}, size_factor=image_factor)
             for video_element in ele["video"]
         ]
-        nframes = adjust_by_factor(len(images), FRAME_FACTOR, method="ceil")
+        nframes = adjust_by_factor(len(images), FRAME_FACTOR, method='ceil')
         if len(images) < nframes:
             images.extend([images[-1]] * (nframes - len(images)))
-
-        timestamps = [-1 for i in range(nframes)]  # not sure about this
+        
+        timestamps = [-1 for i in range(nframes)] # not sure about this
         if return_video_sample_fps:
             return images, process_info.pop("fps", 2.0), timestamps
         return images
-
-
+    
 class Eagle3_VLProcessorKwargs(ProcessingKwargs, total=False):
     # see processing_utils.ProcessingKwargs documentation for usage.
     _defaults = {
@@ -582,22 +502,18 @@ class Eagle3_VLProcessor(ProcessorMixin):
         tokenizer=None,
         vision_feature_select_strategy=None,
         chat_template=None,
-        image_token="<IMG_CONTEXT>",
-        video_token="<IMG_CONTEXT>",
-        pixels_per_token=28 * 28,
-        image_placeholder="image",
-        video_placeholder="video",
-        image_start_token="<img>",
-        image_end_token="</img>",
+        image_token='<IMG_CONTEXT>',
+        video_token='<IMG_CONTEXT>',
+        pixels_per_token=28*28,
+        image_placeholder='image',
+        video_placeholder='video',
+        image_start_token='<img>',
+        image_end_token='</img>',
         **kwargs,
-    ):
+    ):  
         self.vision_feature_select_strategy = vision_feature_select_strategy
-        self.image_token = (
-            tokenizer.image_token if hasattr(tokenizer, "image_token") else image_token
-        )
-        self.video_token = (
-            tokenizer.video_token if hasattr(tokenizer, "video_token") else video_token
-        )
+        self.image_token = tokenizer.image_token if hasattr(tokenizer, "image_token") else image_token
+        self.video_token = tokenizer.video_token if hasattr(tokenizer, "video_token") else video_token
         self.image_token_id = (
             tokenizer.image_token_id
             if getattr(tokenizer, "image_token_id", None)
@@ -613,22 +529,19 @@ class Eagle3_VLProcessor(ProcessorMixin):
         self.pixels_per_token = pixels_per_token
         self.image_start_token = image_start_token
         self.image_end_token = image_end_token
-        if "auto_map" in kwargs:
-            self.auto_map = kwargs["auto_map"]
+        if 'auto_map' in kwargs:
+            self.auto_map = kwargs['auto_map']
         super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
-    def replace_media_placeholder(
-        self, text, image_list, video_list, timestamps_list, fps_list, **output_kwargs
-    ):
+    
+    def replace_media_placeholder(self, text, image_list, video_list, timestamps_list, fps_list, **output_kwargs):
 
         num_of_images_in_this_sample = 0
         num_of_videos_in_this_sample = 0
         # Regular expression pattern to match formats like <image-1> or <video-2>
-        pattern = re.compile(
-            rf"<({self.image_placeholder}|{self.video_placeholder})-(\d+)>"
-        )
+        pattern = re.compile(rf"<({self.image_placeholder}|{self.video_placeholder})-(\d+)>")
         unified_frame_list = []
-
+        
         # Function to replace tags in a single text
         def replace_in_text(text):
             # repl callback function for each match replacement operation
@@ -636,115 +549,64 @@ class Eagle3_VLProcessor(ProcessorMixin):
                 nonlocal unified_frame_list
                 nonlocal num_of_images_in_this_sample
                 nonlocal num_of_videos_in_this_sample
-                media_type = match.group(1)  # 'image' or 'video'
-                idx_in_list = int(match.group(2)) - 1  # Convert to list index (0-based)
+                media_type = match.group(1)          # 'image' or 'video'
+                idx_in_list = int(match.group(2)) - 1   # Convert to list index (0-based)
                 # Select the corresponding path based on media type
-                idx_mapper = {
-                    0: "first",
-                    1: "second",
-                    2: "third",
-                    3: "fourth",
-                    4: "fifth",
-                    5: "sixth",
-                    6: "seventh",
-                    7: "eighth",
-                    8: "ninth",
-                    9: "tenth",
-                }
-                if media_type == "image":
-                    image_inputs = self.image_processor(
-                        images=[image_list[idx_in_list]],
-                        videos=None,
-                        **output_kwargs["images_kwargs"],
-                    )
-                    image_height, image_width = image_inputs["image_sizes"][0]
-                    assert (
-                        image_height <= IMAGE_MAX_SIZE and image_width <= IMAGE_MAX_SIZE
-                    ), f"image_height: {image_height}, image_width: {image_width}"
+                idx_mapper = {0: "first", 1: "second", 2: "third", 3: "fourth", 4: "fifth", 5: "sixth", 6: "seventh", 7: "eighth", 8: "ninth", 9: "tenth"}  
+                if media_type == 'image':
+                    image_inputs = self.image_processor(images=[image_list[idx_in_list]], videos=None, **output_kwargs["images_kwargs"])
+                    image_height, image_width = image_inputs['image_sizes'][0]
+                    assert image_height <= IMAGE_MAX_SIZE and image_width <= IMAGE_MAX_SIZE, f"image_height: {image_height}, image_width: {image_width}"
                     image_tokens = image_height * image_width // self.pixels_per_token
                     special_placeholder = f"<image {idx_in_list+1}>{self.image_start_token}{self.image_token * image_tokens}{self.image_end_token}"
                     unified_frame_list.append(image_inputs)
                     num_of_images_in_this_sample += 1
-
-                elif media_type == "video":
-
-                    video_inputs = self.image_processor(
-                        images=None,
-                        videos=video_list[idx_in_list],
-                        **output_kwargs["videos_kwargs"],
-                    )
-                    N, C, image_height, image_width = video_inputs["pixel_values"].shape
+                    
+                elif media_type == 'video':
+                    
+                    video_inputs = self.image_processor(images=None, videos=video_list[idx_in_list], **output_kwargs["videos_kwargs"])
+                    N, C, image_height, image_width = video_inputs['pixel_values'].shape
                     image_tokens = image_height * image_width // self.pixels_per_token
-
-                    assert (
-                        image_height <= IMAGE_MAX_SIZE and image_width <= IMAGE_MAX_SIZE
-                    ), f"image_height: {image_height}, image_width: {image_width}"
-
+                    
+                    assert image_height <= IMAGE_MAX_SIZE and image_width <= IMAGE_MAX_SIZE, f"image_height: {image_height}, image_width: {image_width}"
+                    
                     if timestamps_list is not None and -1 not in timestamps_list:
                         frame_timestamps = timestamps_list[idx_in_list]
                     else:
                         frame_timestamps = None
-                    sampled_fps = (
-                        fps_list[idx_in_list] if fps_list is not None else None
-                    )
-
+                    sampled_fps = fps_list[idx_in_list] if fps_list is not None else None
+                    
                     num_of_tokens_list = [image_tokens] * N
-
+  
                     if frame_timestamps is not None:
-                        assert len(frame_timestamps) == len(
-                            num_of_tokens_list
-                        ), f"The number of timestamps is not equal to the number of frames: {len(frame_timestamps)} != {len(num_of_tokens_list)}"
-                        special_placeholder = [
-                            f"Frame {i+1} sample at {frame_timestamps[i]:.2f}s: {self.image_start_token}{self.image_token * num_of_tokens}{self.image_end_token}"
-                            for i, num_of_tokens in enumerate(num_of_tokens_list)
-                        ]
+                        assert len(frame_timestamps) == len(num_of_tokens_list), f"The number of timestamps is not equal to the number of frames: {len(frame_timestamps)} != {len(num_of_tokens_list)}"
+                        special_placeholder = [f"Frame {i+1} sample at {frame_timestamps[i]:.2f}s: {self.image_start_token}{self.image_token * num_of_tokens}{self.image_end_token}" for i, num_of_tokens in enumerate(num_of_tokens_list)]
                     else:
-                        special_placeholder = [
-                            f"Frame {i+1}: {self.image_start_token}{self.image_token * num_of_tokens}{self.image_end_token}"
-                            for i, num_of_tokens in enumerate(num_of_tokens_list)
-                        ]
-
+                        special_placeholder = [f"Frame {i+1}: {self.image_start_token}{self.image_token * num_of_tokens}{self.image_end_token}" for i, num_of_tokens in enumerate(num_of_tokens_list)]
+                    
                     if sampled_fps is not None:
-                        special_placeholder = (
-                            f"The {idx_mapper[idx_in_list]} video sampled with {sampled_fps:.2f} fps: "
-                            + "".join(special_placeholder)
-                        )
+                        special_placeholder = f"The {idx_mapper[idx_in_list]} video sampled with {sampled_fps:.2f} fps: " + "".join(special_placeholder)
                     else:
-                        special_placeholder = (
-                            f"The {idx_mapper[idx_in_list]} video: "
-                            + "".join(special_placeholder)
-                        )
+                        special_placeholder = f"The {idx_mapper[idx_in_list]} video: " + "".join(special_placeholder)
                     unified_frame_list.append(video_inputs)
                     num_of_videos_in_this_sample += 1
                 else:
-                    raise ValueError(f"Unknown media type: {media_type}")
+                    raise ValueError(f'Unknown media type: {media_type}')
                 return special_placeholder
-
             return pattern.sub(repl, text)
-
         text = replace_in_text(text)
         if len(unified_frame_list) > 0:
-            pixel_values = [frame["pixel_values"] for frame in unified_frame_list]
-            image_sizes = torch.cat(
-                [frame["image_sizes"] for frame in unified_frame_list], dim=0
-            )
+            pixel_values = [frame['pixel_values'] for frame in unified_frame_list]
+            image_sizes = torch.cat([frame['image_sizes'] for frame in unified_frame_list], dim=0)
         else:
             pixel_values = []
             image_sizes = []
-        return (
-            text,
-            pixel_values,
-            image_sizes,
-            num_of_images_in_this_sample,
-            num_of_videos_in_this_sample,
-        )
-
+        return text, pixel_values, image_sizes, num_of_images_in_this_sample, num_of_videos_in_this_sample
+    
     def __call__(
         self,
         images: ImageInput = None,
-        text: Union[
-            TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]
-        ] = None,
+        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
         audio=None,
         videos: VideoInput = None,
         **kwargs: Unpack[Eagle3_VLProcessorKwargs],
@@ -776,54 +638,34 @@ class Eagle3_VLProcessor(ProcessorMixin):
             - **image_sizes** -- Size of each image that will be used to unpad an image. Returned when `images` is not `None`.
         """
 
+
         output_kwargs = self._merge_kwargs(
             Eagle3_VLProcessorKwargs,
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,
             **kwargs,
         )
-
+        
         if isinstance(text, str):
             text_list = [text]
         elif not isinstance(text, list) and not isinstance(text[0], str):
-            raise ValueError(
-                "Invalid input text. Please provide a string, or a list of strings"
-            )
+            raise ValueError("Invalid input text. Please provide a string, or a list of strings")
         elif isinstance(text, list) and isinstance(text[0], str):
             text_list = text
-
-        if images is None:
-            images = []
-        if videos is None:
-            videos = []
-
+        
+        if images is None: images = []
+        if videos is None: videos = []
+        
         pixel_values_list = []
         image_sizes_list = []
         new_sample_list = []
         image_start_idx = 0
         video_start_idx = 0
-        timestamps_batch = output_kwargs["videos_kwargs"].pop("timestamps", None)
-        fps_batch = output_kwargs["videos_kwargs"].pop("fps", None)
+        timestamps_batch = output_kwargs['videos_kwargs'].pop("timestamps", None)
+        fps_batch = output_kwargs['videos_kwargs'].pop("fps", None)
         for sample in text_list:
-            timestamps_list = (
-                timestamps_batch[video_start_idx:]
-                if timestamps_batch is not None
-                else None
-            )
+            timestamps_list = timestamps_batch[video_start_idx:] if timestamps_batch is not None else None
             fps_list = fps_batch[video_start_idx:] if fps_batch is not None else None
-            (
-                sample,
-                pixel_values,
-                image_sizes,
-                num_of_images_in_this_sample,
-                num_of_videos_in_this_sample,
-            ) = self.replace_media_placeholder(
-                sample,
-                images[image_start_idx:],
-                videos[video_start_idx:],
-                timestamps_list,
-                fps_list,
-                **output_kwargs,
-            )
+            sample, pixel_values, image_sizes, num_of_images_in_this_sample, num_of_videos_in_this_sample = self.replace_media_placeholder(sample, images[image_start_idx:], videos[video_start_idx:], timestamps_list, fps_list, **output_kwargs)
             new_sample_list.append(sample)
             pixel_values_list.extend(pixel_values)
             image_sizes_list.extend(image_sizes)
@@ -833,8 +675,8 @@ class Eagle3_VLProcessor(ProcessorMixin):
 
         if len(pixel_values) > 0:
             image_inputs = {
-                "pixel_values": pixel_values_list,
-                "image_sizes": torch.stack(image_sizes_list, dim=0),
+                'pixel_values':pixel_values_list,
+                'image_sizes': torch.stack(image_sizes_list, dim=0)
             }
         else:
             image_inputs = {}
@@ -868,9 +710,7 @@ class Eagle3_VLProcessor(ProcessorMixin):
     # override to save video-config in a separate config file
     def save_pretrained(self, save_directory, **kwargs):
         if os.path.isfile(save_directory):
-            raise ValueError(
-                f"Provided path ({save_directory}) should be a directory, not a file"
-            )
+            raise ValueError(f"Provided path ({save_directory}) should be a directory, not a file")
         os.makedirs(save_directory, exist_ok=True)
 
         outputs = super().save_pretrained(save_directory, **kwargs)
@@ -891,11 +731,7 @@ class Eagle3_VLProcessor(ProcessorMixin):
         self,
         conversations: list[dict] | list[list[dict]],
         return_video_kwargs: bool = False,
-    ) -> tuple[
-        list[Image.Image] | None,
-        list[torch.Tensor | list[Image.Image]] | None,
-        Optional[dict],
-    ]:
+    ) -> tuple[list[Image.Image] | None, list[torch.Tensor | list[Image.Image]] | None, Optional[dict]]:
 
         vision_infos = self.extract_vision_info(conversations)
         ## Read images or videos
@@ -907,9 +743,7 @@ class Eagle3_VLProcessor(ProcessorMixin):
             if "image" in vision_info or "image_url" in vision_info:
                 image_inputs.append(fetch_image(vision_info))
             elif "video" in vision_info:
-                video_input, video_sample_fps, video_timestamps = fetch_video(
-                    vision_info, return_video_sample_fps=True
-                )
+                video_input, video_sample_fps, video_timestamps = fetch_video(vision_info, return_video_sample_fps=True)
                 video_sample_fps_list.append(video_sample_fps)
                 video_inputs.append(video_input)
                 video_timestamps_list.append(video_timestamps)
@@ -920,16 +754,10 @@ class Eagle3_VLProcessor(ProcessorMixin):
         if len(video_inputs) == 0:
             video_inputs = None
         if return_video_kwargs:
-            return (
-                image_inputs,
-                video_inputs,
-                {"fps": video_sample_fps_list, "timestamps": video_timestamps_list},
-            )
+            return image_inputs, video_inputs, {'fps': video_sample_fps_list, 'timestamps': video_timestamps_list}
         return image_inputs, video_inputs
 
-    def extract_vision_info(
-        self, conversations: list[dict] | list[list[dict]]
-    ) -> list[dict]:
+    def extract_vision_info(self, conversations: list[dict] | list[list[dict]]) -> list[dict]:
         vision_infos = []
         if isinstance(conversations[0], dict):
             conversations = [conversations]
@@ -945,13 +773,11 @@ class Eagle3_VLProcessor(ProcessorMixin):
                         ):
                             vision_infos.append(ele)
         return vision_infos
-
-    def py_apply_chat_template(
-        self, messages, tokenize=False, add_generation_prompt=False
-    ):
+    
+    def py_apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
         """
         Renders a chat conversation using a custom template with verification of tokens.
-        The purpose is to check for the existence of tokens like "<image-1>" or "<video-1>"
+        The purpose is to check for the existence of tokens like "<image-1>" or "<video-1>" 
         in the message text and skip adding them if they already exist.
         Args:
             messages (list): A list of message dictionaries. Each message should contain:
@@ -969,13 +795,12 @@ class Eagle3_VLProcessor(ProcessorMixin):
         result = ""
         image_count = 0
         video_count = 0
-
+        
         message_text = ""
         for idx, message in enumerate(messages):
-            if message.get("role") != "user":
-                continue
+            if message.get('role') != 'user': continue
             # If content is a string, simply output it.
-            content = message.get("content")
+            content = message.get('content')
             if isinstance(content, str):
                 message_text += content
             elif isinstance(content, list):
@@ -987,17 +812,17 @@ class Eagle3_VLProcessor(ProcessorMixin):
                     # If an item is already a string in the list, add it directly.
                     elif isinstance(item, str):
                         message_text += item
-
+                        
         for idx, message in enumerate(messages):
             # If the first message is not from the system, prepend a default system message.
-            if idx == 0 and message.get("role") != "system":
+            if idx == 0 and message.get('role') != 'system':
                 result += "<|im_start|>system\n"
                 result += "You are a helpful assistant.\n"
                 result += "<|im_end|>\n"
 
             # Start the current message block with its role.
             result += f"<|im_start|>{message.get('role', '')}\n"
-            content = message.get("content")
+            content = message.get('content')
 
             # If content is a string, simply output it.
             if isinstance(content, str):
@@ -1007,28 +832,22 @@ class Eagle3_VLProcessor(ProcessorMixin):
                 # Process each content item.
                 for item in content:
                     # Check if the item is an image (explicitly by type or by key presence).
-                    if isinstance(item, dict) and (
-                        item.get("type") == "image"
-                        or "image" in item
-                        or "image_url" in item
-                    ):
+                    if (isinstance(item, dict) and (item.get('type') == 'image' or 'image' in item or 'image_url' in item)):
                         image_count += 1
                         candidate_token = f"<image-{image_count}>"
                         # Only add the token if it is not already present in the collected text.
                         if candidate_token not in message_text:
                             result += candidate_token
                     # Check if the item is a video.
-                    elif isinstance(item, dict) and (
-                        item.get("type") == "video" or "video" in item
-                    ):
+                    elif (isinstance(item, dict) and (item.get('type') == 'video' or 'video' in item)):
                         video_count += 1
                         candidate_token = f"<video-{video_count}>"
                         # Only add the token if it is not already present.
                         if candidate_token not in message_text:
                             result += candidate_token
                     # If the item contains text, add it.
-                    elif isinstance(item, dict) and "text" in item:
-                        result += item["text"]
+                    elif isinstance(item, dict) and 'text' in item:
+                        result += item['text']
                     # If the item is a string (and not handled already), add it.
                     elif isinstance(item, str):
                         result += item
@@ -1039,6 +858,7 @@ class Eagle3_VLProcessor(ProcessorMixin):
             result += "<|im_start|>assistant\n"
 
         return result
+
 
     @classmethod
     def from_args_and_dict(cls, args, processor_dict: dict[str, Any], **kwargs):
@@ -1063,12 +883,10 @@ class Eagle3_VLProcessor(ProcessorMixin):
         if "processor_class" in processor_dict:
             del processor_dict["processor_class"]
 
-        # if "auto_map" in processor_dict:
+        #if "auto_map" in processor_dict:
         #    del processor_dict["auto_map"]
 
-        unused_kwargs = cls.validate_init_kwargs(
-            processor_config=processor_dict, valid_kwargs=cls.valid_kwargs
-        )
+        unused_kwargs = cls.validate_init_kwargs(processor_config=processor_dict, valid_kwargs=cls.valid_kwargs)
         processor = cls(*args, **processor_dict)
 
         # Update processor with kwargs if needed
@@ -1082,6 +900,6 @@ class Eagle3_VLProcessor(ProcessorMixin):
             return processor, kwargs
         else:
             return processor
-
-
+        
+        
 __all__ = ["Eagle3_VLProcessor"]

--- a/gr00t/policy/gr00t_policy.py
+++ b/gr00t/policy/gr00t_policy.py
@@ -97,8 +97,8 @@ class Gr00tPolicy(BasePolicy):
         # Currently only supports single language input per timestep
         language_keys = self.modality_configs["language"].modality_keys
         language_delta_indices = self.modality_configs["language"].delta_indices
-        assert len(language_keys) == 1, "Only one language key is supported"
         assert len(language_delta_indices) == 1, "Only one language delta index is supported"
+        assert len(language_keys) == 1, "Only one language key is supported"
         self.language_key = language_keys[0]
 
     def _unbatch_observation(self, value: dict[str, Any]) -> list[dict[str, Any]]:

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -1,225 +1,222 @@
-# GR00T Deployment & Inference Guide
+# GR00T N1.6 TensorRT Deployment Guide
 
-Run inference with PyTorch or TensorRT acceleration for the GR00T policy.
+TensorRT acceleration for GR00T N1.6 inference. Converts 6 model components to TRT engines for faster inference on NVIDIA GPUs.
 
----
+## What Is Optimized
+
+The following 6 trainable components are exported to ONNX and compiled into TRT engines:
+
+| Engine | Description | Notes |
+|--------|-------------|-------|
+| **ViT** (Siglip2) | Vision encoder, 27 transformer layers | Largest backbone component |
+| **LLM** (Qwen3) | Language model, 16 transformer layers | Exported with eager attention (no flash) |
+| **State Encoder** | Embodiment-specific state MLP | Small, BF16 even in FP8 mode |
+| **Action Encoder** | Multi-embodiment action encoder | Small, BF16 even in FP8 mode |
+| **DiT** | Flow-matching diffusion transformer, 32 layers | Runs 4× per inference (denoising loop) |
+| **Action Decoder** | Embodiment-specific action MLP | Small, BF16 even in FP8 mode |
+
+### What Is NOT Optimized (remains in PyTorch)
+
+- **pixel_shuffle_back + MLP1**: Data-dependent reshape after ViT (~1ms)
+- **VLLN**: Single LayerNorm(2048), negligible latency
+- **Position embedding**: Lightweight lookup in denoising loop
+- **Embedding layer + vision token scatter**: Python-level token placement logic
+- **Data processing**: Tokenizer, image preprocessing (CPU-bound, ~5ms)
+
+These components contribute ~6ms combined overhead that is included in all reported timings below.
 
 ## Prerequisites
 
-- Model checkpoint (e.g., `nvidia/GR00T-N1.6-3B`)
-- Dataset in LeRobot format
-- CUDA-enabled GPU
+- CUDA-enabled GPU with sufficient VRAM (tested on H100 80GB)
+- Model checkpoint (base or finetuned)
+- Dataset in LeRobot format (needed during export to capture input shapes)
+- FP8 mode requires Hopper architecture (H100) or newer; RTX 4090 and Jetson Thor support BF16 only
 
 ### Installation
 
-**PyTorch mode** (default installation):
 ```bash
-uv sync
+uv sync --extra=gpu
 ```
 
-**TensorRT mode** (includes ONNX and TensorRT dependencies):
+This installs `flash-attn`, `onnx`, and `tensorrt`.
+
+---
+
+## Quick Start
+
+The pipeline script handles export, build, validation, and benchmarking:
+
 ```bash
-uv sync --extra tensorrt
+# BF16
+bash scripts/deployment/run_trt_pipeline.sh export_bf16       # ~5-10 min on H100
+bash scripts/deployment/run_trt_pipeline.sh build_bf16        # ~10-20 min on H100
+bash scripts/deployment/run_trt_pipeline.sh compare_detailed  # ~2 min
+bash scripts/deployment/run_trt_pipeline.sh benchmark         # ~5 min
+
+# FP8 (H100 / Hopper only)
+bash scripts/deployment/run_trt_pipeline.sh export_fp8        # ~15-20 min (includes calibration)
+bash scripts/deployment/run_trt_pipeline.sh build_fp8         # ~10-20 min
+bash scripts/deployment/run_trt_pipeline.sh compare_detailed_fp8
+bash scripts/deployment/run_trt_pipeline.sh benchmark_fp8
+```
+
+> **Build times**: ONNX export takes ~5-10 minutes, TRT engine build takes ~10-20 minutes per precision mode. Engines are GPU-architecture specific — they must be rebuilt when switching between different GPUs (e.g., H100 vs RTX 4090).
+
+### Exporting a Finetuned Model
+
+The export workflow is identical for base and finetuned models. Override `MODEL` with your checkpoint path:
+
+```bash
+MODEL=/path/to/finetuned/checkpoint bash scripts/deployment/run_trt_pipeline.sh export_bf16
+MODEL=/path/to/finetuned/checkpoint bash scripts/deployment/run_trt_pipeline.sh build_bf16
+```
+
+The checkpoint directory must contain:
+- `config.json` — model architecture config
+- `model-*.safetensors` — model weights (one or more shards)
+- `model.safetensors.index.json` — weight shard index
+- `processor_config.json` — processor configuration
+
+Example with a finetuned LIBERO checkpoint:
+
+```bash
+MODEL=/tmp/libero_10/checkpoint-20000 \
+DATASET=path/to/libero_dataset \
+bash scripts/deployment/run_trt_pipeline.sh export_bf16
+```
+
+### Changing Embodiment or Dataset
+
+```bash
+MODEL=/path/to/checkpoint \
+EMBODIMENT=NEW_EMBODIMENT \
+DATASET=path/to/your/dataset \
+bash scripts/deployment/run_trt_pipeline.sh export_bf16
 ```
 
 ---
 
-## Quick Start: PyTorch Mode
+## Embodiment Compatibility
+
+All testing was performed with **GR1** embodiment using `demo_data/gr1.PickNPlace`. The TRT engines use dynamic inputs (batch size, sequence length) and the `embodiment_id` input selects the correct MLP branch at runtime, so **a single set of engines supports multiple embodiments without re-exporting**.
+
+However, there are constraints that may require re-exporting:
+
+| Constraint | Default Value | Impact |
+|------------|--------------|--------|
+| `max_state_dim` | 128 | Embodiments with state dim > 128 need re-export |
+| `max_action_dim` | 128 | Embodiments with action dim > 128 need re-export |
+| `action_horizon` | 50 | Fixed at export time |
+| `image_size` | 252 (auto-detected) | Different image resolutions need re-export (ViT engine is resolution-specific) |
+| `llm_seq_len` | Dynamic (min=1, max=512) | Multi-view setups produce longer sequences; covered by dynamic shape profiles |
+
+---
+
+## Running Inference with TRT Engines
+
+### Policy Server (for sim evaluation or real robot)
 
 ```bash
-python scripts/deployment/standalone_inference_script.py \
-  --model-path nvidia/GR00T-N1.6-3B \
-  --dataset-path /path/to/dataset \
-  --embodiment-tag GR1 \
-  --traj-ids 0 1 2 \
-  --inference-mode pytorch \
-  --action-horizon 8
+uv run python gr00t/eval/run_gr00t_server.py \
+    --model_path nvidia/GR00T-N1.6-3B \
+    --embodiment_tag GR1 \
+    --port 5556 \
+    --trt_engine_path ./groot_n1d6_engines \
+    --trt_mode full_pipeline
 ```
 
----
-
-## TensorRT Mode (2x Faster)
-
-### Step 1: Export to ONNX
+### Standalone Benchmark
 
 ```bash
-python scripts/deployment/export_onnx_n1d6.py \
-  --model-path nvidia/GR00T-N1.6-3B \
-  --dataset-path /path/to/dataset \
-  --embodiment-tag GR1 \
-  --output-dir ./groot_n1d6_onnx
-```
-
-**Output:** `./groot_n1d6_onnx/dit_model.onnx`
-
-### Step 2: Build TensorRT Engine
-
-```bash
-python scripts/deployment/build_tensorrt_engine.py \
-  --onnx ./groot_n1d6_onnx/dit_model.onnx \
-  --engine ./groot_n1d6_onnx/dit_model_bf16.trt \
-  --precision bf16
-```
-
-**Output:** `./groot_n1d6_onnx/dit_model_bf16.trt`
-
-> **Note:** Engine build takes ~5-10 minutes depending on GPU. The engine is GPU-specific and needs to be rebuilt for different GPU architectures.
-
-### Step 3: Run with TensorRT
-
-```bash
-python scripts/deployment/standalone_inference_script.py \
-  --model-path nvidia/GR00T-N1.6-3B \
-  --dataset-path /path/to/dataset \
-  --embodiment-tag GR1 \
-  --traj-ids 0 1 2 \
-  --inference-mode tensorrt \
-  --trt-engine-path ./groot_n1d6_onnx/dit_model_bf16.trt \
-  --action-horizon 8
+uv run python scripts/deployment/benchmark_inference.py \
+    --model_path nvidia/GR00T-N1.6-3B \
+    --dataset_path demo_data/gr1.PickNPlace \
+    --trt_engine_path ./groot_n1d6_engines \
+    --trt_mode full_pipeline
 ```
 
 ---
 
-## Command-Line Arguments
+## Performance (H100 80GB)
 
-### `standalone_inference_script.py`
+Model: GR00T-N1.6-3B, 4 denoising steps, GR1 embodiment, single-view.
 
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `--model-path` | (required) | Path to model checkpoint |
-| `--dataset-path` | (required) | Path to LeRobot dataset |
-| `--embodiment-tag` | `GR1` | Embodiment tag |
-| `--traj-ids` | `[0]` | List of trajectory IDs to evaluate |
-| `--steps` | `200` | Max steps per trajectory |
-| `--action-horizon` | `16` | Action horizon for inference |
-| `--inference-mode` | `pytorch` | `pytorch` or `tensorrt` |
-| `--trt-engine-path` | `./groot_n1d6_onnx/dit_model_bf16.trt` | TensorRT engine path |
-| `--denoising-steps` | `4` | Number of denoising steps |
-| `--skip-timing-steps` | `1` | Steps to skip for timing (warmup) |
-| `--seed` | `42` | Random seed for reproducibility |
-| `--video-backend` | `torchcodec` | Video backend (`decord`, `torchvision_av`, `torchcodec`) |
+### Inference Timing
 
-### `export_onnx_n1d6.py`
+| Mode | Data Proc | Backbone | Action Head | E2E | Frequency |
+|------|-----------|----------|-------------|-----|-----------|
+| PyTorch Eager | 5 ms | 39 ms | 93 ms | 137 ms | 7.3 Hz |
+| torch.compile | 5 ms | 39 ms | 11 ms | 55 ms | 18.3 Hz |
+| **TRT BF16** | 5 ms | **6 ms** | **12 ms** | **24 ms** | **42.3 Hz** |
+| **TRT FP8** | 4 ms | **5 ms** | **10 ms** | **19 ms** | **52.5 Hz** |
 
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `--model-path` | (required) | Path to model checkpoint |
-| `--dataset-path` | (required) | Path to dataset (for input shape capture) |
-| `--embodiment-tag` | `GR1` | Embodiment tag |
-| `--output-dir` | `./groot_n1d6_onnx` | Output directory for ONNX model |
-| `--video-backend` | `torchcodec` | Video backend |
+> **Note**: These frequencies measure model inference time only (data processing + backbone + action head). In a real deployment loop, additional overhead from sensor I/O, image preprocessing, network latency (if using server/client), and control loop timing will reduce the effective frequency. Expect actual deployment frequency to be lower than these numbers.
 
-### `build_tensorrt_engine.py`
-
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `--onnx` | (required) | Path to ONNX model |
-| `--engine` | (required) | Path to save TensorRT engine |
-| `--precision` | `bf16` | Precision (`fp32`, `fp16`, `bf16`, `fp8`) |
-| `--workspace` | `8192` | Workspace size in MB |
-
-### `benchmark_inference.py`
-
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `--model-path` | `nvidia/GR00T-N1.6-3B` | Path to model checkpoint |
-| `--dataset-path` | `demo_data/gr1.PickNPlace` | Path to dataset |
-| `--embodiment-tag` | `GR1` | Embodiment tag |
-| `--trt-engine-path` | (optional) | Path to TensorRT engine |
-| `--num-iterations` | `20` | Number of benchmark iterations |
-| `--warmup` | `5` | Number of warmup iterations |
-| `--skip-compile` | `false` | Skip torch.compile benchmark |
-| `--seed` | `42` | Random seed for reproducibility |
+> **Other GPUs**: These numbers are from H100. Performance on RTX 4090, A100, or Jetson Thor will differ. FP8 is only available on Hopper (H100) and newer architectures. Run `bash scripts/deployment/run_trt_pipeline.sh benchmark` on your target hardware to measure actual performance.
 
 ---
 
-## Benchmarks
+## Accuracy Validation
 
-### Component-wise Breakdown
+### Method
 
-> **Note:** The backbone (Vision Encoder + Language Model) timing is the same across all modes (Eager, torch.compile, TensorRT). Only the **Action Head (DiT)** is optimized with torch.compile or TensorRT, which is why you see significant speedups in the Action Head column while the Backbone column remains constant.
+Accuracy is verified at three levels:
 
-GR00T-N1.6-3B inference timing (4 denoising steps):
+1. **Per-Component Isolation** (`--compare-detailed`): Each TRT engine is tested independently — the same input is fed to both the PyTorch module and the TRT engine, and their outputs are compared via cosine similarity. This isolates each engine's precision from upstream drift.
 
-| Device | Mode | Data Processing | Backbone | Action Head | E2E | Frequency |
-|--------|------|-----------------|----------|-------------|-----|-----------|
-| RTX 5090 | PyTorch Eager | 2 ms | 18 ms | 38 ms | 58 ms | 17.3 Hz |
-| RTX 5090 | torch.compile | 2 ms | 18 ms | 16 ms | 37 ms | 27.3 Hz |
-| RTX 5090 | TensorRT | 2 ms | 18 ms | 11 ms | 31 ms | 32.1 Hz |
-| H100 | PyTorch Eager | 4 ms | 23 ms | 49 ms | 77 ms | 13.0 Hz |
-| H100 | torch.compile | 4 ms | 23 ms | 11 ms | 38 ms | 26.3 Hz |
-| H100 | TensorRT | 4 ms | 22 ms | 10 ms | 36 ms | 27.9 Hz |
-| RTX 4090 | PyTorch Eager | 2 ms | 25 ms | 55 ms | 82 ms | 12.2 Hz |
-| RTX 4090 | torch.compile | 2 ms | 25 ms | 17 ms | 44 ms | 22.8 Hz |
-| RTX 4090 | TensorRT | 2 ms | 24 ms | 16 ms | 43 ms | 23.3 Hz |
-| Thor | PyTorch Eager | 5 ms | 38 ms | 74 ms | 117 ms | 8.6 Hz |
-| Thor | torch.compile | 5 ms | 39 ms | 61 ms | 105 ms | 9.5 Hz |
-| Thor | TensorRT | 5 ms | 38 ms | 49 ms | 92 ms | 10.9 Hz |
-| Orin | PyTorch Eager | 6 ms | 93 ms | 202 ms | 300 ms | 3.3 Hz |
-| Orin | torch.compile | 6 ms | 93 ms | 101 ms | 199 ms | 5.0 Hz |
-| Orin | TensorRT | 6 ms | 95 ms | 72 ms | 173 ms | 5.8 Hz |
+2. **End-to-End Action Output** (`--compare`): Both PyTorch and TRT pipelines process the same observation with the same random noise. The final action predictions are compared.
 
+3. **Task Success Rate** (RoboCasa simulation): Cosine similarity alone does not guarantee correct robot behavior over long episodes. The full RoboCasa GR1 tabletop evaluation suite (24 tasks, 20 episodes each) measures task success rate for each inference backend.
 
-### Speedup vs PyTorch Eager
+### Per-Component Cosine Similarity (BF16)
 
-| Device | Mode | E2E Speedup | Action Head Speedup |
-|--------|------|-------------|---------------------|
-| RTX 5090 | PyTorch Eager | 1.00x | 1.00x |
-| RTX 5090 | torch.compile | 1.58x | 2.32x |
-| RTX 5090 | TensorRT | 1.86x | 3.59x |
-| H100 | PyTorch Eager | 1.00x | 1.00x |
-| H100 | torch.compile | 2.02x | 4.60x |
-| H100 | TensorRT | 2.14x | 4.80x |
-| RTX 4090 | PyTorch Eager | 1.00x | 1.00x |
-| RTX 4090 | torch.compile | 1.87x | 3.26x |
-| RTX 4090 | TensorRT | 1.92x | 3.48x |
-| Thor | PyTorch Eager | 1.00x | 1.00x |
-| Thor | torch.compile | 1.11x | 1.20x |
-| Thor | TensorRT | 1.27x | 1.49x |
-| Orin | PyTorch Eager | 1.00x | 1.00x |
-| Orin | torch.compile | 1.50x | 2.00x |
-| Orin | TensorRT | 1.73x | 2.80x |
+| Component | Cosine Similarity | Status |
+|-----------|-------------------|--------|
+| ViT (Siglip2) | 0.998375 | WARN (flash→TRT attention drift, inherent to export) |
+| LLM (Qwen3) | 0.999777 | PASS |
+| State Encoder | 1.000000 | PASS |
+| Action Encoder | 0.999996 | PASS |
+| DiT | 0.999993 | PASS |
+| Action Decoder | 1.000000 | PASS |
+| **E2E Action** | **0.999998** | **PASS** |
 
-> Run `python scripts/deployment/benchmark_inference.py` to generate benchmarks for your hardware.
-> See `GR00T_inference_timing.ipynb` for detailed analysis and visualizations.
+### RoboCasa Task Success Rate (24 tasks, 20 episodes each)
 
-> Experiments on Thor and Orin used different dependency stacks. Thor with CUDA 13, PyTorch 2.9, using supporting packages sourced from the [Jetson AI Lab cu130 index](https://pypi.jetson-ai-lab.io/sbsa/cu130); and Orin with CUDA 12.6, PyTorch 2.8, using supporting packages sourced from the [Jetson AI Lab cu126 index](https://pypi.jetson-ai-lab.io/jp6/cu126).
----
+| Mode | Avg Success Rate | Statistically Significant vs Eager? |
+|------|-----------------|-------------------------------------|
+| PyTorch Eager | 0.5048 | — |
+| TRT BF16 | 0.4618 | NO (t=-1.78, p>0.05) |
+| TRT FP8 | 0.5060 | NO (t=+0.04, p>0.05) |
 
-## Troubleshooting
+Neither TRT mode shows statistically significant degradation. Differences are within simulation variance.
 
-### Engine Build Fails
-
-- Ensure you have enough GPU memory (8GB+ recommended)
-- Try reducing workspace size: `--workspace 4096`
-- Ensure TensorRT version matches your CUDA version
-
-### ONNX Export Issues
-
-- If export fails, ensure the model loads correctly in PyTorch first
-- Check that the dataset path is valid and contains at least one trajectory
+> **Note**: The RoboCasa evaluation takes **3+ hours per backend** (24 tasks × 20 episodes × 720 max steps). Running all three backends sequentially takes ~10 hours. Use `bash scripts/deployment/eval_trt_robocasa.sh quick` for a faster smoke test (2 episodes).
 
 ---
 
-## Architecture
+## Architecture Diagram
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    GR00T Policy                             │
-│  ┌───────────────┐  ┌───────────────┐  ┌─────────────────┐  │
-│  │ Vision Encoder│  │Language Model │  │  Action Head    │  │
-│  │(Cosmos-Reason)│──│(Cosmos-Reason)│──│    (DiT)        │  │
-│  └───────────────┘  └───────────────┘  └─────────────────┘  │
-│                                              ▲              │
-│                                              │              │
-│                                    ┌─────────┴─────────┐    │
-│                                    │ TensorRT Engine   │    │
-│                                    │ (dit_model.trt)   │    │
-│                                    └───────────────────┘    │
-└─────────────────────────────────────────────────────────────┘
-```
+┌──────────────────────────────────────────────────────────────────┐
+│                     GR00T Policy                                 │
+│                                                                  │
+│  Backbone:                                                       │
+│  ┌──────────┐   ┌──────────────┐   ┌─────────┐   ┌──────────┐  │
+│  │ ViT (TRT)│ → │pixel_shuffle │ → │MLP1 (PT)│ → │ LLM (TRT)│  │
+│  │ Siglip2  │   │  (PyTorch)   │   │         │   │  Qwen3   │  │
+│  └──────────┘   └──────────────┘   └─────────┘   └──────────┘  │
+│                                                                  │
+│  Action Head:                                                    │
+│  ┌────────┐  ┌──────────────┐  ┌─────────┐  ┌──────────────┐   │
+│  │VLLN(PT)│→ │State Enc(TRT)│→ │DiT (TRT)│→ │Act Dec (TRT) │   │
+│  └────────┘  └──────────────┘  │×4 steps  │  └──────────────┘   │
+│              ┌──────────────┐  │          │                      │
+│              │Act Enc (TRT) │→ │          │                      │
+│              └──────────────┘  └─────────┘                       │
+└──────────────────────────────────────────────────────────────────┘
 
-The TensorRT optimization targets the **DiT (Diffusion Transformer)** component of the action head, which is the main computational bottleneck during inference.
+TRT = TensorRT engine    PT = PyTorch (small ops, not worth TRT overhead)
+```
 
 ---
 
@@ -227,8 +224,38 @@ The TensorRT optimization targets the **DiT (Diffusion Transformer)** component 
 
 | File | Description |
 |------|-------------|
-| `standalone_inference_script.py` | Main inference script (PyTorch + TensorRT) |
-| `export_onnx_n1d6.py` | Export DiT model to ONNX format |
-| `build_tensorrt_engine.py` | Build TensorRT engine from ONNX |
-| `benchmark_inference.py` | Benchmark data processing, backbone, action head, and E2E timing |
-| `GR00T_inference_timing.ipynb` | Inference timing analysis notebook with visualizations |
+| `run_trt_pipeline.sh` | Pipeline runner: export → build → validate → benchmark |
+| `export_onnx_n1d6.py` | Export 6 components to ONNX (BF16 or FP8 with calibration) |
+| `build_tensorrt_engine.py` | Build TRT engines from ONNX (auto shape profiles from metadata) |
+| `benchmark_inference.py` | Benchmark and accuracy comparison (`--compare`, `--compare-detailed`) |
+| `trt_model_forward.py` | TRT forward functions and engine setup (monkey-patches policy) |
+| `trt_torch.py` | TRT engine wrapper class |
+| `eval_trt_robocasa.sh` | RoboCasa sim evaluation across backends (eager vs BF16 vs FP8) |
+| `vit_trt_compile.py` | Experimental: torch_tensorrt ViT compilation (preserves SDPA) |
+| `accuracy_thresholds.py` | Centralized accuracy thresholds for validation |
+
+---
+
+## Troubleshooting
+
+### Engine Build Fails
+- Ensure 8GB+ GPU memory available
+- Try `--workspace 4096` to reduce memory usage
+- Engines are GPU-architecture specific — rebuild when switching GPUs
+
+### TRT Version Mismatch
+- Engines must be built with the same TRT version used at runtime
+- Check: `python -c "import tensorrt; print(tensorrt.__version__)"`
+- Rebuild engines after TRT version upgrades
+
+### flash-attn Not Found
+- Run `uv sync --extra=gpu` (bare `uv sync` removes flash-attn)
+
+### ONNX Export Fails
+- Ensure model loads in PyTorch first
+- Ensure dataset has at least 1 trajectory
+- Check `export_metadata.json` is generated in output dir
+
+### FP8 Not Available
+- FP8 requires Hopper architecture (H100) or newer
+- RTX 4090 (Ada) and Jetson Thor support BF16 only

--- a/scripts/deployment/accuracy_thresholds.py
+++ b/scripts/deployment/accuracy_thresholds.py
@@ -1,0 +1,43 @@
+"""Centralized accuracy thresholds for TRT deployment validation.
+
+Single source of truth for all cosine similarity and L1 thresholds used
+in benchmark_inference.py (compare modes) and export_onnx_n1d6.py (ViT
+wrapper verification).  Import from here instead of hardcoding values.
+
+See also: scripts/deployment/run_trt_pipeline.sh (acceptance criteria).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccuracyThreshold:
+    """Immutable pair of cosine-similarity minimum and optional L1 maximum."""
+
+    cosine_min: float
+    l1_max: float | None  # None = not checked
+
+
+# ── BF16 thresholds ──────────────────────────────────────────────────────────
+
+BF16_BACKBONE = AccuracyThreshold(cosine_min=0.999, l1_max=0.01)
+BF16_ACTION_PRED = AccuracyThreshold(cosine_min=0.99, l1_max=0.05)
+BF16_E2E_ACTION = AccuracyThreshold(cosine_min=0.99, l1_max=None)
+
+# Per-component pass/warn/fail boundaries (detailed compare mode)
+BF16_COMPONENT_PASS = 0.999  # cosine >= this => PASS
+BF16_COMPONENT_WARN = 0.99  # cosine >= this => WARN, else FAIL
+
+# ViT wrapper verification (export_onnx_n1d6.py)
+VIT_WRAPPER_COSINE_MIN = 0.999
+
+# ── FP8 thresholds (relaxed — more drift expected, especially in ViT) ────────
+
+FP8_BACKBONE = AccuracyThreshold(cosine_min=0.99, l1_max=0.05)
+FP8_ACTION_PRED = AccuracyThreshold(cosine_min=0.98, l1_max=0.1)
+FP8_E2E_ACTION = AccuracyThreshold(cosine_min=0.98, l1_max=None)
+
+FP8_COMPONENT_PASS = 0.99
+FP8_COMPONENT_WARN = 0.98

--- a/scripts/deployment/benchmark_inference.py
+++ b/scripts/deployment/benchmark_inference.py
@@ -22,6 +22,7 @@ Usage:
 
 import argparse
 import os
+import sys
 import time
 
 import gr00t
@@ -32,6 +33,21 @@ from gr00t.data.types import MessageType, VLAStepData
 from gr00t.policy.gr00t_policy import Gr00tPolicy
 import numpy as np
 import torch
+import torch.nn.functional as F
+
+
+# Ensure scripts/deployment/ is on sys.path for sibling module imports
+_DEPLOY_DIR = os.path.dirname(os.path.abspath(__file__))
+if _DEPLOY_DIR not in sys.path:
+    sys.path.insert(0, _DEPLOY_DIR)
+
+from accuracy_thresholds import (  # noqa: E402
+    BF16_ACTION_PRED,
+    BF16_BACKBONE,
+    BF16_COMPONENT_PASS,
+    BF16_COMPONENT_WARN,
+    BF16_E2E_ACTION,
+)
 
 
 def set_seed(seed: int = 42):
@@ -297,6 +313,735 @@ def print_markdown_table(results, device_name, denoising_steps):
     print("\n" + "=" * 100)
 
 
+# ============================================================
+# Accuracy Comparison: TRT vs PyTorch
+# ============================================================
+
+
+def compare_tensors(name, ref, test):
+    """Compare two tensors and print accuracy metrics.
+
+    Args:
+        name: Label for this comparison
+        ref: Reference tensor (PyTorch)
+        test: Test tensor (TRT)
+
+    Returns:
+        dict with cosine_sim, l1_mean, l1_max, relative_error
+    """
+    ref_f = ref.float().cpu().flatten()
+    test_f = test.float().cpu().flatten()
+
+    # Cosine similarity
+    cos_sim = F.cosine_similarity(ref_f.unsqueeze(0), test_f.unsqueeze(0)).item()
+
+    # L1 distance
+    diff = (ref_f - test_f).abs()
+    l1_mean = diff.mean().item()
+    l1_max = diff.max().item()
+
+    # Relative error (avoid division by zero)
+    ref_abs = ref_f.abs()
+    nonzero = ref_abs > 1e-8
+    if nonzero.any():
+        rel_err = (diff[nonzero] / ref_abs[nonzero]).mean().item()
+    else:
+        rel_err = 0.0
+
+    # Value range
+    ref_min, ref_max, ref_mean = ref_f.min().item(), ref_f.max().item(), ref_f.mean().item()
+    test_min, test_max, test_mean = test_f.min().item(), test_f.max().item(), test_f.mean().item()
+
+    print(f"\n  [{name}]")
+    print(f"    Cosine Similarity:  {cos_sim:.6f}")
+    print(f"    L1 Mean / Max:      {l1_mean:.6f} / {l1_max:.6f}")
+    print(f"    Relative Error:     {rel_err:.6f}")
+    print(f"    Ref  range: [{ref_min:.4f}, {ref_max:.4f}] mean={ref_mean:.4f}")
+    print(f"    Test range: [{test_min:.4f}, {test_max:.4f}] mean={test_mean:.4f}")
+
+    return {
+        "cosine_sim": cos_sim,
+        "l1_mean": l1_mean,
+        "l1_max": l1_max,
+        "relative_error": rel_err,
+    }
+
+
+def compare_numpy_arrays(name, ref, test):
+    """Compare two numpy arrays and print accuracy metrics.
+
+    Args:
+        name: Label for this comparison
+        ref: Reference numpy array (PyTorch output)
+        test: Test numpy array (TRT output)
+
+    Returns:
+        dict with cosine_sim, l1_mean, l1_max, relative_error
+    """
+    return compare_tensors(
+        name,
+        torch.from_numpy(ref.astype(np.float32)),
+        torch.from_numpy(test.astype(np.float32)),
+    )
+
+
+def run_compare_mode(args, policy_pytorch, policy_trt, observation, device):
+    """Run accuracy comparison between PyTorch and TRT policies.
+
+    Both policies run the same observation with fixed random noise for the
+    denoising process. Compares outputs at backbone, action head, and
+    final denormalized action levels.
+
+    Args:
+        args: CLI arguments
+        policy_pytorch: Gr00tPolicy with PyTorch backend
+        policy_trt: Gr00tPolicy with TRT engines loaded
+        observation: Single observation dict
+        device: CUDA device
+    """
+    print("\n" + "=" * 100)
+    print("ACCURACY COMPARISON: PyTorch vs TensorRT")
+    print("=" * 100)
+
+    # Fix random noise for reproducible comparison
+    set_seed(args.seed)
+    init_actions = torch.randn(
+        1,
+        policy_pytorch.model.action_head.config.action_horizon,
+        policy_pytorch.model.action_head.action_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    # Set init_actions on both policies so they use the same starting noise
+    policy_pytorch.model.action_head.init_actions = init_actions
+    policy_trt.model.action_head.init_actions = init_actions
+
+    # --- Level 1: Backbone output comparison ---
+    print("\n--- Level 1: Backbone Features ---")
+    collated_inputs = prepare_model_inputs(policy_pytorch, observation)
+    with torch.inference_mode():
+        backbone_inputs_pt, action_inputs_pt = policy_pytorch.model.prepare_input(collated_inputs)
+        backbone_out_pt = policy_pytorch.model.backbone(backbone_inputs_pt)
+
+    collated_inputs_trt = prepare_model_inputs(policy_trt, observation)
+    with torch.inference_mode():
+        backbone_inputs_trt, action_inputs_trt = policy_trt.model.prepare_input(collated_inputs_trt)
+        backbone_out_trt = policy_trt.model.backbone(backbone_inputs_trt)
+
+    backbone_metrics = compare_tensors(
+        "backbone_features",
+        backbone_out_pt.backbone_features,
+        backbone_out_trt.backbone_features,
+    )
+
+    # --- Level 2: Action head output comparison ---
+    print("\n--- Level 2: Action Prediction (normalized) ---")
+    with torch.inference_mode():
+        action_out_pt = policy_pytorch.model.action_head.get_action(
+            backbone_out_pt, action_inputs_pt
+        )
+        action_out_trt = policy_trt.model.action_head.get_action(
+            backbone_out_trt, action_inputs_trt
+        )
+
+    action_metrics = compare_tensors(
+        "action_pred", action_out_pt.action_pred, action_out_trt.action_pred
+    )
+
+    # --- Level 3: Full end-to-end get_action (denormalized) ---
+    print("\n--- Level 3: Denormalized Action (end-to-end) ---")
+    set_seed(args.seed)
+    policy_pytorch.model.action_head.init_actions = init_actions.clone()
+    policy_trt.model.action_head.init_actions = init_actions.clone()
+
+    action_pt, _ = policy_pytorch.get_action(observation)
+    action_trt, _ = policy_trt.get_action(observation)
+
+    e2e_metrics = {}
+    for key in action_pt:
+        if key in action_trt:
+            m = compare_numpy_arrays(f"action.{key}", action_pt[key], action_trt[key])
+            e2e_metrics[key] = m
+
+    # --- Summary ---
+    print("\n" + "=" * 100)
+    print("ACCURACY SUMMARY")
+    print("=" * 100)
+
+    all_pass = True
+    checks = [
+        ("Backbone Features", backbone_metrics, BF16_BACKBONE),
+        ("Action Pred", action_metrics, BF16_ACTION_PRED),
+    ]
+    for name, metrics, thresh in checks:
+        cos_ok = metrics["cosine_sim"] >= thresh.cosine_min
+        l1_ok = thresh.l1_max is None or metrics["l1_mean"] <= thresh.l1_max
+        status = "PASS" if (cos_ok and l1_ok) else "FAIL"
+        if status == "FAIL":
+            all_pass = False
+        print(
+            f"  {name:25s}: cosine={metrics['cosine_sim']:.6f} "
+            f"(>={thresh.cosine_min}? {cos_ok})  "
+            f"L1_mean={metrics['l1_mean']:.6f} (<={thresh.l1_max}? {l1_ok})  "
+            f"=> {status}"
+        )
+
+    for key, metrics in e2e_metrics.items():
+        cos_ok = metrics["cosine_sim"] >= BF16_E2E_ACTION.cosine_min
+        status = "PASS" if cos_ok else "FAIL"
+        if not cos_ok:
+            all_pass = False
+        print(
+            f"  action.{key:19s}: cosine={metrics['cosine_sim']:.6f}  "
+            f"L1_mean={metrics['l1_mean']:.6f}  => {status}"
+        )
+
+    print(f"\n  Overall: {'ALL PASS' if all_pass else 'SOME FAILED'}")
+    print("=" * 100)
+
+    # Clean up init_actions
+    if hasattr(policy_pytorch.model.action_head, "init_actions"):
+        del policy_pytorch.model.action_head.init_actions
+    if hasattr(policy_trt.model.action_head, "init_actions"):
+        del policy_trt.model.action_head.init_actions
+
+
+def run_detailed_compare_mode(args, policy_pytorch, policy_trt, observation, device):
+    """Run detailed per-component accuracy tests between PyTorch and TRT.
+
+    Tests each of the 6 TRT engines in isolation (identical input → compare output),
+    then runs integration tests to isolate action head drift from backbone drift
+    and per-step denoising drift from compounding.
+
+    Part A (Tests 1-6): Per-component isolation
+    Part B (Tests 7-8): Integration tests
+
+    Args:
+        args: CLI arguments
+        policy_pytorch: Gr00tPolicy with PyTorch backend (all modules intact)
+        policy_trt: Gr00tPolicy with TRT engines loaded (PyTorch modules deleted)
+        observation: Single observation dict
+        device: CUDA device
+    """
+    print("\n" + "=" * 72)
+    print("  DETAILED PER-COMPONENT ACCURACY TEST")
+    print("=" * 72)
+
+    # Access models
+    backbone_pt = policy_pytorch.model.backbone
+    backbone_trt = policy_trt.model.backbone
+    action_head_pt = policy_pytorch.model.action_head
+    action_head_trt = policy_trt.model.action_head
+    eagle_model = backbone_pt.model  # Eagle3_VLForConditionalGeneration
+    engine_dtype = torch.bfloat16
+
+    # Prepare common inputs (using PyTorch policy's processor)
+    collated_inputs = prepare_model_inputs(policy_pytorch, observation)
+    with torch.inference_mode():
+        backbone_inputs, action_inputs = policy_pytorch.model.prepare_input(collated_inputs)
+
+    pixel_values = backbone_inputs["pixel_values"]
+    input_ids = backbone_inputs["input_ids"]
+    attention_mask = backbone_inputs["attention_mask"]
+    if attention_mask.dtype != torch.int64:
+        attention_mask = attention_mask.to(torch.int64)
+
+    state = action_inputs["state"]
+    if state.dtype != engine_dtype:
+        state = state.to(engine_dtype)
+    embodiment_id = action_inputs["embodiment_id"]
+    if embodiment_id.dtype != torch.int64:
+        embodiment_id = embodiment_id.to(torch.int64)
+
+    batch_size = state.shape[0]
+    results = {}
+
+    # ===================================================================
+    # Part A: Component Isolation (same input → compare output)
+    # ===================================================================
+    print("\n--- Part A: Component Isolation (same input -> compare output) ---")
+
+    # ------ Test 1: ViT (Siglip2) ------
+    has_vit_engine = hasattr(backbone_trt, "vit_engine") and backbone_trt.vit_engine is not None
+    if has_vit_engine:
+        if isinstance(pixel_values, (list, tuple)):
+            pv = torch.cat(pixel_values, dim=0)
+        else:
+            pv = pixel_values
+        if pv.dtype != engine_dtype:
+            pv = pv.to(engine_dtype)
+
+        print("\n  [1/6] ViT (Siglip2)")
+        print(f"    Input: pixel_values {tuple(pv.shape)}")
+
+        with torch.inference_mode():
+            original_vit = eagle_model.vision_model.vision_model
+            vit_out_pt = original_vit([pv]).last_hidden_state
+
+            backbone_trt.vit_engine.set_runtime_tensor_shape("pixel_values", pv.shape)
+            vit_out_trt = backbone_trt.vit_engine(pv)["vit_embeds"]
+
+        results["ViT"] = compare_tensors("1/6 ViT (Siglip2)", vit_out_pt, vit_out_trt)
+    else:
+        print("\n  [1/6] ViT (Siglip2) — SKIPPED (no vit_engine found)")
+
+    # ------ Test 2: LLM (Qwen3, truncated) ------
+    # Build input_embeds: ViT → pixel_shuffle → mlp1 → embed scatter
+    # Note: PyTorch LLM may use flash attention while TRT uses eager attention,
+    # so small numerical differences from attention implementation are expected.
+    print(f"\n  [2/6] LLM (Qwen3, {len(backbone_pt.model.language_model.model.layers)} layers)")
+
+    with torch.inference_mode():
+        # Compute ViT embeddings (using full PyTorch pipeline including pixel_shuffle + mlp1)
+        vit_embeds = eagle_model.extract_feature(pixel_values)  # [B*N, C]
+
+        # Create input embeddings and scatter vision tokens
+        embedding_layer = eagle_model.language_model.get_input_embeddings()
+        input_embeds = embedding_layer(input_ids).to(engine_dtype)
+        vit_embeds = vit_embeds.to(engine_dtype)
+
+        B, N, C = input_embeds.shape
+        input_embeds_flat = input_embeds.reshape(B * N, C)
+        input_ids_flat = input_ids.reshape(B * N)
+        selected = input_ids_flat == eagle_model.config.image_token_index
+        input_embeds_flat[selected] = input_embeds_flat[selected] * 0.0 + vit_embeds.reshape(-1, C)
+        input_embeds = input_embeds_flat.reshape(B, N, C)
+
+        print(f"    Input: input_embeds {tuple(input_embeds.shape)}")
+
+        # PyTorch LLM: run Qwen3Model (already truncated to select_layer layers)
+        qwen3_model = eagle_model.language_model.model  # Qwen3Model
+        llm_out_pt = qwen3_model(
+            inputs_embeds=input_embeds, attention_mask=attention_mask
+        ).last_hidden_state
+
+        # TRT LLM
+        backbone_trt.llm_engine.set_runtime_tensor_shape("inputs_embeds", input_embeds.shape)
+        backbone_trt.llm_engine.set_runtime_tensor_shape("attention_mask", attention_mask.shape)
+        llm_out_trt = backbone_trt.llm_engine(input_embeds, attention_mask)["embeddings"]
+
+    results["LLM"] = compare_tensors("2/6 LLM (Qwen3)", llm_out_pt, llm_out_trt)
+
+    # ------ Test 3: State Encoder ------
+    print("\n  [3/6] State Encoder")
+    print(f"    Input: state {tuple(state.shape)}, embodiment_id {tuple(embodiment_id.shape)}")
+
+    with torch.inference_mode():
+        state_out_pt = action_head_pt.state_encoder(state, embodiment_id)
+
+        action_head_trt.state_encoder_engine.set_runtime_tensor_shape("state", state.shape)
+        action_head_trt.state_encoder_engine.set_runtime_tensor_shape(
+            "embodiment_id", embodiment_id.shape
+        )
+        state_out_trt = action_head_trt.state_encoder_engine(state, embodiment_id)["output"]
+
+    results["State Encoder"] = compare_tensors("3/6 State Encoder", state_out_pt, state_out_trt)
+
+    # ------ Test 4: Action Encoder ------
+    print("\n  [4/6] Action Encoder")
+    set_seed(args.seed)
+    actions_noise = torch.randn(
+        batch_size,
+        action_head_pt.config.action_horizon,
+        action_head_pt.action_dim,
+        dtype=engine_dtype,
+        device=device,
+    )
+    t_val = 0  # first denoising step
+    timesteps = torch.full((batch_size,), fill_value=t_val, device=device, dtype=torch.int64)
+    print(
+        f"    Input: actions {tuple(actions_noise.shape)}, "
+        f"timesteps [t={t_val}], embodiment_id {tuple(embodiment_id.shape)}"
+    )
+
+    with torch.inference_mode():
+        action_enc_out_pt = action_head_pt.action_encoder(actions_noise, timesteps, embodiment_id)
+
+        action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+            "actions", actions_noise.shape
+        )
+        action_head_trt.action_encoder_engine.set_runtime_tensor_shape("timesteps", timesteps.shape)
+        action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+            "embodiment_id", embodiment_id.shape
+        )
+        action_enc_out_trt = action_head_trt.action_encoder_engine(
+            actions_noise, timesteps, embodiment_id
+        )["output"]
+
+    results["Action Encoder"] = compare_tensors(
+        "4/6 Action Encoder", action_enc_out_pt, action_enc_out_trt
+    )
+
+    # ------ Test 5: DiT (single forward, t=0) ------
+    print("\n  [5/6] DiT (single forward, t=0)")
+
+    # Build sa_embs and vl_embs using PyTorch outputs
+    with torch.inference_mode():
+        # Get backbone output for vl_embs
+        backbone_out_pt = backbone_pt(backbone_inputs)
+        vl_embs = action_head_pt.vlln(backbone_out_pt.backbone_features).to(engine_dtype)
+        image_mask = backbone_out_pt.image_mask
+        bb_attn_mask = backbone_out_pt.backbone_attention_mask
+
+        # Build sa_embs: state encoder output + action encoder output (with pos embed)
+        action_features = action_enc_out_pt.clone()
+        if action_head_pt.config.add_pos_embed:
+            pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+            pos_embs = action_head_pt.position_embedding(pos_ids).unsqueeze(0).to(engine_dtype)
+            action_features = action_features + pos_embs
+
+        sa_embs = torch.cat((state_out_pt, action_features), dim=1).to(engine_dtype)
+
+    print(f"    Input: sa_embs {tuple(sa_embs.shape)}, vl_embs {tuple(vl_embs.shape)}")
+
+    with torch.inference_mode():
+        # PyTorch DiT
+        if action_head_pt.config.use_alternate_vl_dit:
+            dit_out_pt = action_head_pt.model(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs,
+                timestep=timesteps,
+                image_mask=image_mask,
+                backbone_attention_mask=bb_attn_mask,
+            )
+        else:
+            dit_out_pt = action_head_pt.model(
+                hidden_states=sa_embs,
+                encoder_hidden_states=vl_embs,
+                timestep=timesteps,
+            )
+
+        # TRT DiT
+        action_head_trt.dit_engine.set_runtime_tensor_shape("sa_embs", sa_embs.shape)
+        action_head_trt.dit_engine.set_runtime_tensor_shape("vl_embs", vl_embs.shape)
+        action_head_trt.dit_engine.set_runtime_tensor_shape("timestep", timesteps.shape)
+
+        dit_kwargs = {}
+        if image_mask is not None:
+            action_head_trt.dit_engine.set_runtime_tensor_shape("image_mask", image_mask.shape)
+            dit_kwargs["image_mask"] = image_mask
+        if bb_attn_mask is not None:
+            action_head_trt.dit_engine.set_runtime_tensor_shape(
+                "backbone_attention_mask", bb_attn_mask.shape
+            )
+            dit_kwargs["backbone_attention_mask"] = bb_attn_mask
+
+        dit_out_trt = action_head_trt.dit_engine(sa_embs, vl_embs, timesteps, **dit_kwargs)[
+            "output"
+        ]
+
+    results["DiT"] = compare_tensors("5/6 DiT (single step)", dit_out_pt, dit_out_trt)
+
+    # ------ Test 6: Action Decoder ------
+    print("\n  [6/6] Action Decoder")
+    print(f"    Input: model_output {tuple(dit_out_pt.shape)}")
+
+    with torch.inference_mode():
+        decoder_out_pt = action_head_pt.action_decoder(dit_out_pt, embodiment_id)
+
+        action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+            "model_output", dit_out_pt.shape
+        )
+        action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+            "embodiment_id", embodiment_id.shape
+        )
+        decoder_out_trt = action_head_trt.action_decoder_engine(dit_out_pt, embodiment_id)["output"]
+
+    results["Action Decoder"] = compare_tensors(
+        "6/6 Action Decoder", decoder_out_pt, decoder_out_trt
+    )
+
+    # ===================================================================
+    # Part B: Integration Tests
+    # ===================================================================
+    print("\n--- Part B: Integration Tests ---")
+
+    # ------ Test 7: Action Head with SAME backbone output ------
+    # Both PyTorch and TRT action heads receive the SAME backbone output
+    # (from PyTorch). Isolates action head TRT drift from backbone drift.
+    print("\n  [7] Action Head (same backbone output)")
+
+    set_seed(args.seed)
+    init_actions = torch.randn(
+        batch_size,
+        action_head_pt.config.action_horizon,
+        action_head_pt.action_dim,
+        dtype=engine_dtype,
+        device=device,
+    )
+
+    num_steps = action_head_pt.num_inference_timesteps
+    dt = 1.0 / num_steps
+
+    with torch.inference_mode():
+        # PyTorch denoising loop (manual — for explicit noise control)
+        state_features_pt = action_head_pt.state_encoder(state, embodiment_id)
+        actions_pt = init_actions.clone()
+
+        for t in range(num_steps):
+            t_cont = t / float(num_steps)
+            t_disc = int(t_cont * action_head_pt.num_timestep_buckets)
+            ts = torch.full((batch_size,), fill_value=t_disc, device=device, dtype=torch.int64)
+
+            af = action_head_pt.action_encoder(actions_pt, ts, embodiment_id)
+            if action_head_pt.config.add_pos_embed:
+                pos_ids = torch.arange(af.shape[1], dtype=torch.long, device=device)
+                pos_embs = action_head_pt.position_embedding(pos_ids).unsqueeze(0)
+                af = af + pos_embs
+
+            sa = torch.cat((state_features_pt, af), dim=1)
+
+            if action_head_pt.config.use_alternate_vl_dit:
+                mo = action_head_pt.model(
+                    hidden_states=sa,
+                    encoder_hidden_states=vl_embs,
+                    timestep=ts,
+                    image_mask=image_mask,
+                    backbone_attention_mask=bb_attn_mask,
+                )
+            else:
+                mo = action_head_pt.model(
+                    hidden_states=sa,
+                    encoder_hidden_states=vl_embs,
+                    timestep=ts,
+                )
+
+            pred = action_head_pt.action_decoder(mo, embodiment_id)
+            actions_pt = actions_pt + dt * pred[:, -action_head_pt.action_horizon :]
+
+        # TRT denoising loop (using TRT engines, same backbone features + noise)
+        action_head_trt.state_encoder_engine.set_runtime_tensor_shape("state", state.shape)
+        action_head_trt.state_encoder_engine.set_runtime_tensor_shape(
+            "embodiment_id", embodiment_id.shape
+        )
+        state_features_trt = action_head_trt.state_encoder_engine(state, embodiment_id)["output"]
+
+        actions_trt = init_actions.clone()
+
+        for t in range(num_steps):
+            t_cont = t / float(num_steps)
+            t_disc = int(t_cont * action_head_pt.num_timestep_buckets)
+            ts = torch.full((batch_size,), fill_value=t_disc, device=device, dtype=torch.int64)
+
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+                "actions", actions_trt.shape
+            )
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape("timesteps", ts.shape)
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+                "embodiment_id", embodiment_id.shape
+            )
+            af_trt = action_head_trt.action_encoder_engine(
+                actions_trt.to(engine_dtype), ts, embodiment_id
+            )["output"]
+
+            if action_head_pt.config.add_pos_embed:
+                pos_ids = torch.arange(af_trt.shape[1], dtype=torch.long, device=device)
+                pos_embs = action_head_pt.position_embedding(pos_ids).unsqueeze(0).to(engine_dtype)
+                af_trt = af_trt + pos_embs
+
+            sa_trt = torch.cat((state_features_trt, af_trt), dim=1).to(engine_dtype)
+
+            action_head_trt.dit_engine.set_runtime_tensor_shape("sa_embs", sa_trt.shape)
+            action_head_trt.dit_engine.set_runtime_tensor_shape("vl_embs", vl_embs.shape)
+            action_head_trt.dit_engine.set_runtime_tensor_shape("timestep", ts.shape)
+
+            dit_kw = {}
+            if image_mask is not None:
+                action_head_trt.dit_engine.set_runtime_tensor_shape("image_mask", image_mask.shape)
+                dit_kw["image_mask"] = image_mask
+            if bb_attn_mask is not None:
+                action_head_trt.dit_engine.set_runtime_tensor_shape(
+                    "backbone_attention_mask", bb_attn_mask.shape
+                )
+                dit_kw["backbone_attention_mask"] = bb_attn_mask
+
+            mo_trt = action_head_trt.dit_engine(sa_trt, vl_embs, ts, **dit_kw)["output"]
+
+            action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+                "model_output", mo_trt.shape
+            )
+            action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+                "embodiment_id", embodiment_id.shape
+            )
+            pred_trt = action_head_trt.action_decoder_engine(mo_trt, embodiment_id)["output"]
+            actions_trt = actions_trt + dt * pred_trt[:, -action_head_pt.action_horizon :]
+
+    results["Action Head (same backbone)"] = compare_tensors(
+        "7 Action Head (same backbone)", actions_pt, actions_trt
+    )
+
+    # ------ Test 8: Per-step Denoising (lockstep) ------
+    # At each step, TRT receives the SAME inputs as PyTorch (not its own
+    # previous output). Shows isolated per-step drift vs compounding.
+    print("\n  [8] Per-step Denoising (lockstep)")
+
+    set_seed(args.seed)
+    actions_lock = torch.randn(
+        batch_size,
+        action_head_pt.config.action_horizon,
+        action_head_pt.action_dim,
+        dtype=engine_dtype,
+        device=device,
+    )
+
+    step_results = []
+    with torch.inference_mode():
+        state_features_lock = action_head_pt.state_encoder(state, embodiment_id)
+
+        for t in range(num_steps):
+            t_cont = t / float(num_steps)
+            t_disc = int(t_cont * action_head_pt.num_timestep_buckets)
+            ts = torch.full((batch_size,), fill_value=t_disc, device=device, dtype=torch.int64)
+
+            # --- PyTorch path ---
+            af_pt = action_head_pt.action_encoder(actions_lock, ts, embodiment_id)
+            if action_head_pt.config.add_pos_embed:
+                pos_ids = torch.arange(af_pt.shape[1], dtype=torch.long, device=device)
+                pos_embs = action_head_pt.position_embedding(pos_ids).unsqueeze(0)
+                af_pt = af_pt + pos_embs
+
+            sa_pt = torch.cat((state_features_lock, af_pt), dim=1)
+
+            if action_head_pt.config.use_alternate_vl_dit:
+                dit_pt = action_head_pt.model(
+                    hidden_states=sa_pt,
+                    encoder_hidden_states=vl_embs,
+                    timestep=ts,
+                    image_mask=image_mask,
+                    backbone_attention_mask=bb_attn_mask,
+                )
+            else:
+                dit_pt = action_head_pt.model(
+                    hidden_states=sa_pt,
+                    encoder_hidden_states=vl_embs,
+                    timestep=ts,
+                )
+
+            dec_pt = action_head_pt.action_decoder(dit_pt, embodiment_id)
+
+            # --- TRT path (same inputs as PyTorch) ---
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+                "actions", actions_lock.shape
+            )
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape("timesteps", ts.shape)
+            action_head_trt.action_encoder_engine.set_runtime_tensor_shape(
+                "embodiment_id", embodiment_id.shape
+            )
+            af_trt_lock = action_head_trt.action_encoder_engine(
+                actions_lock.to(engine_dtype), ts, embodiment_id
+            )["output"]
+
+            if action_head_pt.config.add_pos_embed:
+                pos_ids = torch.arange(af_trt_lock.shape[1], dtype=torch.long, device=device)
+                pos_embs = action_head_pt.position_embedding(pos_ids).unsqueeze(0).to(engine_dtype)
+                af_trt_lock = af_trt_lock + pos_embs
+
+            # Use PyTorch state encoder output for lockstep
+            sa_trt_lock = torch.cat((state_features_lock, af_trt_lock), dim=1).to(engine_dtype)
+
+            action_head_trt.dit_engine.set_runtime_tensor_shape("sa_embs", sa_trt_lock.shape)
+            action_head_trt.dit_engine.set_runtime_tensor_shape("vl_embs", vl_embs.shape)
+            action_head_trt.dit_engine.set_runtime_tensor_shape("timestep", ts.shape)
+
+            dit_kw = {}
+            if image_mask is not None:
+                action_head_trt.dit_engine.set_runtime_tensor_shape("image_mask", image_mask.shape)
+                dit_kw["image_mask"] = image_mask
+            if bb_attn_mask is not None:
+                action_head_trt.dit_engine.set_runtime_tensor_shape(
+                    "backbone_attention_mask", bb_attn_mask.shape
+                )
+                dit_kw["backbone_attention_mask"] = bb_attn_mask
+
+            dit_trt_lock = action_head_trt.dit_engine(sa_trt_lock, vl_embs, ts, **dit_kw)["output"]
+
+            action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+                "model_output", dit_trt_lock.shape
+            )
+            action_head_trt.action_decoder_engine.set_runtime_tensor_shape(
+                "embodiment_id", embodiment_id.shape
+            )
+            dec_trt_lock = action_head_trt.action_decoder_engine(dit_trt_lock, embodiment_id)[
+                "output"
+            ]
+
+            # Compare at this step
+            dit_cos = F.cosine_similarity(
+                dit_pt.float().flatten().unsqueeze(0),
+                dit_trt_lock.float().flatten().unsqueeze(0),
+            ).item()
+            dec_cos = F.cosine_similarity(
+                dec_pt.float().flatten().unsqueeze(0),
+                dec_trt_lock.float().flatten().unsqueeze(0),
+            ).item()
+            step_results.append({"dit_cosine": dit_cos, "dec_cosine": dec_cos})
+            print(f"    Step {t}: DiT cosine={dit_cos:.6f}, Decoder cosine={dec_cos:.6f}")
+
+            # Advance using PyTorch output (lockstep — TRT follows PyTorch's trajectory)
+            pred_velocity = dec_pt[:, -action_head_pt.action_horizon :]
+            actions_lock = actions_lock + dt * pred_velocity
+
+    results["Per-step Lockstep"] = step_results
+
+    # ===================================================================
+    # Summary
+    # ===================================================================
+    print("\n" + "=" * 72)
+    print("  SUMMARY")
+    print("=" * 72)
+
+    # Part A summary
+    worst_name = None
+    worst_cosine = 1.0
+    part_a_names = [
+        "ViT",
+        "LLM",
+        "State Encoder",
+        "Action Encoder",
+        "DiT",
+        "Action Decoder",
+    ]
+    for name in part_a_names:
+        if name not in results:
+            continue
+        m = results[name]
+        cos = m["cosine_sim"]
+        status = (
+            "PASS"
+            if cos >= BF16_COMPONENT_PASS
+            else ("WARN" if cos >= BF16_COMPONENT_WARN else "FAIL")
+        )
+        print(f"  {name:25s}: cosine={cos:.6f}  L1_mean={m['l1_mean']:.6f}  => {status}")
+        if cos < worst_cosine:
+            worst_cosine = cos
+            worst_name = name
+
+    # Part B summary
+    print()
+    if "Action Head (same backbone)" in results:
+        m = results["Action Head (same backbone)"]
+        cos = m["cosine_sim"]
+        status = "PASS" if cos >= BF16_E2E_ACTION.cosine_min else "FAIL"
+        print(
+            f"  {'Action Head (same bb)':25s}: cosine={cos:.6f}  "
+            f"L1_mean={m['l1_mean']:.6f}  => {status}"
+        )
+        if cos < worst_cosine:
+            worst_cosine = cos
+            worst_name = "Action Head (same backbone)"
+
+    if "Per-step Lockstep" in results:
+        steps = results["Per-step Lockstep"]
+        avg_dit = sum(s["dit_cosine"] for s in steps) / len(steps)
+        avg_dec = sum(s["dec_cosine"] for s in steps) / len(steps)
+        print(f"  {'Lockstep avg DiT':25s}: cosine={avg_dit:.6f}")
+        print(f"  {'Lockstep avg Decoder':25s}: cosine={avg_dec:.6f}")
+
+    print(f"\n  Component with most drift: {worst_name} (cosine={worst_cosine:.6f})")
+    print("=" * 72)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Benchmark GR00T inference timing")
     parser.add_argument("--model_path", type=str, default="nvidia/GR00T-N1.6-3B")
@@ -322,10 +1067,32 @@ def main():
         help="Skip torch.compile benchmark (can take a while due to JIT compilation)",
     )
     parser.add_argument(
+        "--trt_mode",
+        type=str,
+        default="full_pipeline",
+        choices=["dit_only", "full_pipeline"],
+        help="TensorRT mode: 'dit_only' or 'full_pipeline' (default: full_pipeline)",
+    )
+    parser.add_argument(
         "--use_trajectory",
         action="store_true",
         help="Benchmark on full trajectory instead of single data point. "
         "This cycles through all steps in an episode for more realistic benchmarking.",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Run accuracy comparison between PyTorch and TensorRT. "
+        "Requires --trt_engine_path. Compares backbone, action head, and "
+        "denormalized action outputs with cosine similarity and L1 metrics.",
+    )
+    parser.add_argument(
+        "--compare-detailed",
+        action="store_true",
+        dest="compare_detailed",
+        help="Run detailed per-component accuracy tests between PyTorch and TensorRT. "
+        "Tests each of the 6 TRT engines in isolation, action head with identical "
+        "backbone output, and per-step denoising lockstep. Requires --trt_engine_path.",
     )
     args = parser.parse_args()
 
@@ -416,6 +1183,73 @@ def main():
             "language": {modality_config["language"].modality_keys[0]: [[step_data.text]]},
         }
 
+    # ========================================
+    # Compare mode: accuracy validation only (skip benchmarking)
+    # ========================================
+    if args.compare:
+        if not args.trt_engine_path or not os.path.exists(args.trt_engine_path):
+            print("ERROR: --compare requires --trt_engine_path pointing to built TRT engines.")
+            return
+
+        from trt_model_forward import setup_tensorrt_engines
+
+        print("Loading TRT policy for comparison...")
+        policy_trt = Gr00tPolicy(
+            model_path=args.model_path,
+            embodiment_tag=EmbodimentTag(args.embodiment_tag),
+            device=device,
+            strict=True,
+        )
+        setup_tensorrt_engines(policy_trt, args.trt_engine_path, mode=args.trt_mode)
+
+        # For compare mode, use a single observation (not trajectory)
+        compare_obs = observation if not isinstance(observation, list) else observation[0]
+
+        # Warmup both policies
+        print("Warming up policies...")
+        for _ in range(3):
+            with torch.inference_mode():
+                _ = policy.get_action(compare_obs)
+                _ = policy_trt.get_action(compare_obs)
+
+        run_compare_mode(args, policy, policy_trt, compare_obs, device)
+        return
+
+    # ========================================
+    # Detailed compare mode: per-component accuracy tests (skip benchmarking)
+    # ========================================
+    if args.compare_detailed:
+        if not args.trt_engine_path or not os.path.exists(args.trt_engine_path):
+            print(
+                "ERROR: --compare-detailed requires --trt_engine_path "
+                "pointing to built TRT engines."
+            )
+            return
+
+        from trt_model_forward import setup_tensorrt_engines
+
+        print("Loading TRT policy for detailed comparison...")
+        policy_trt = Gr00tPolicy(
+            model_path=args.model_path,
+            embodiment_tag=EmbodimentTag(args.embodiment_tag),
+            device=device,
+            strict=True,
+        )
+        setup_tensorrt_engines(policy_trt, args.trt_engine_path, mode=args.trt_mode)
+
+        # Use a single observation (not trajectory)
+        compare_obs = observation if not isinstance(observation, list) else observation[0]
+
+        # Warmup both policies
+        print("Warming up policies...")
+        for _ in range(3):
+            with torch.inference_mode():
+                _ = policy.get_action(compare_obs)
+                _ = policy_trt.get_action(compare_obs)
+
+        run_detailed_compare_mode(args, policy, policy_trt, compare_obs, device)
+        return
+
     results = {}
 
     # ========================================
@@ -504,10 +1338,10 @@ def main():
     # ========================================
     if args.trt_engine_path and os.path.exists(args.trt_engine_path):
         print("\n" + "-" * 50)
-        print("Benchmarking TensorRT...")
+        print(f"Benchmarking TensorRT ({args.trt_mode})...")
         print("-" * 50)
 
-        from standalone_inference_script import replace_dit_with_tensorrt
+        from trt_model_forward import setup_tensorrt_engines
 
         policy_trt = Gr00tPolicy(
             model_path=args.model_path,
@@ -515,7 +1349,7 @@ def main():
             device=device,
             strict=True,
         )
-        replace_dit_with_tensorrt(policy_trt, args.trt_engine_path)
+        setup_tensorrt_engines(policy_trt, args.trt_engine_path, mode=args.trt_mode)
 
         # TensorRT needs extra warmup for engine initialization and CUDA context setup
         trt_warmup = max(args.warmup + 5, 10)
@@ -523,13 +1357,14 @@ def main():
             policy_trt, observation, args.num_iterations, warmup=trt_warmup
         )
 
+        trt_label = f"TensorRT ({args.trt_mode})"
         components = {
             "data_processing": shared_data_processing_times,
             "backbone": times_components["backbone"],
             "action_head": times_components["action_head"],
         }
         components["e2e"] = compute_e2e_from_components(components)
-        results["TensorRT"] = components
+        results[trt_label] = components
 
         e2e_median = np.median(components["e2e"])
         print(f"  E2E:             {e2e_median:.0f} ms ({1000 / e2e_median:.1f} Hz)")
@@ -537,13 +1372,18 @@ def main():
         print(f"  Backbone:        {np.median(components['backbone']):.0f} ms")
         print(f"  Action Head:     {np.median(components['action_head']):.0f} ms")
     elif args.trt_engine_path:
-        print(f"\nTensorRT engine not found: {args.trt_engine_path}")
-        print("To build the engine, run:")
+        print(f"\nTensorRT engine path not found: {args.trt_engine_path}")
+        print("To build engines for full pipeline, run:")
         print(
-            "  python scripts/deployment/export_onnx_n1d6.py --model_path nvidia/GR00T-N1.6-3B --output_dir ./groot_n1d6_onnx"
+            "  python scripts/deployment/export_onnx_n1d6.py "
+            "--model_path nvidia/GR00T-N1.6-3B "
+            "--dataset_path demo_data/gr1.PickNPlace "
+            "--output_dir ./groot_n1d6_onnx --export_mode full_pipeline"
         )
         print(
-            "  python scripts/deployment/build_tensorrt_engine.py --onnx ./groot_n1d6_onnx/dit_model.onnx --engine <path>.trt --precision bf16"
+            "  python scripts/deployment/build_tensorrt_engine.py "
+            "--mode full_pipeline --onnx_dir ./groot_n1d6_onnx "
+            "--engine_dir ./groot_n1d6_engines --precision bf16"
         )
 
     # ========================================

--- a/scripts/deployment/build_tensorrt_engine.py
+++ b/scripts/deployment/build_tensorrt_engine.py
@@ -1,28 +1,144 @@
 #!/usr/bin/env python3
 """
-Build TensorRT Engine from ONNX Model
+Build TensorRT engines from exported ONNX models.
 
-This script builds a TensorRT engine from the exported ONNX DiT model.
-It's equivalent to using trtexec but works with pip-installed TensorRT.
+Supports two modes:
+- single: Build engine for a single ONNX model
+- full_pipeline: Build engines for all pipeline components
+  (ViT, LLM, State Encoder, Action Encoder, DiT, Action Decoder)
+
+Shape profiles are automatically derived from the ONNX models.
 
 Usage:
-    python build_tensorrt_engine.py \
-        --onnx ./groot_n1d6_onnx/dit_model.onnx \
-        --engine ./groot_n1d6_onnx/dit_model_bf16.trt \
+    # Full pipeline:
+    python scripts/deployment/build_tensorrt_engine.py \
+        --mode full_pipeline \
+        --onnx_dir ./groot_n1d6_onnx \
+        --engine_dir ./groot_n1d6_engines \
         --precision bf16
 """
 
 import argparse
+import json
 import logging
 import os
 import time
 
+import onnx
 import tensorrt as trt
 
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+# ============================================================
+# Auto Shape Profile from ONNX
+# ============================================================
+
+
+def derive_shapes_from_onnx(onnx_path, max_batch=8):
+    """Read an ONNX model and derive min/opt/max shape profiles.
+
+    For each input:
+    - Fixed dimensions (concrete values) are kept as-is across min/opt/max.
+    - Dynamic batch dimension: min=1, opt=1, max=max_batch.
+    - Dynamic sequence dimensions: min=1, opt=concrete_value, max=2*concrete_value.
+      (concrete_value comes from the ONNX model's shape hints)
+
+    Returns (min_shapes, opt_shapes, max_shapes) dicts.
+    """
+    model = onnx.load(onnx_path, load_external_data=False)
+
+    min_shapes, opt_shapes, max_shapes = {}, {}, {}
+
+    for inp in model.graph.input:
+        name = inp.name
+        dims = inp.type.tensor_type.shape.dim
+
+        min_shape, opt_shape, max_shape = [], [], []
+        for i, d in enumerate(dims):
+            if d.dim_value > 0:
+                # Fixed dimension — use as-is
+                min_shape.append(d.dim_value)
+                opt_shape.append(d.dim_value)
+                max_shape.append(d.dim_value)
+            else:
+                # Dynamic dimension
+                if i == 0:
+                    # Batch dimension
+                    min_shape.append(1)
+                    opt_shape.append(1)
+                    max_shape.append(max_batch)
+                else:
+                    # Sequence/spatial dimension — use generous range
+                    # We don't know the "typical" value from ONNX alone,
+                    # so use 1 / 1 / large_max. The builder will optimize for opt.
+                    min_shape.append(1)
+                    opt_shape.append(1)
+                    max_shape.append(512)
+
+        min_shapes[name] = tuple(min_shape)
+        opt_shapes[name] = tuple(opt_shape)
+        max_shapes[name] = tuple(max_shape)
+
+    return min_shapes, opt_shapes, max_shapes
+
+
+def derive_shapes_with_hint(onnx_path, opt_seq_lens=None, max_batch=8):
+    """Derive shapes from ONNX, with optional sequence length hints.
+
+    Args:
+        onnx_path: Path to ONNX model
+        opt_seq_lens: Dict mapping dynamic dim names to optimal sequence lengths.
+                      e.g. {"sa_seq_len": 51, "vl_seq_len": 280, "sequence_length": 280}
+        max_batch: Maximum batch size
+    """
+    model = onnx.load(onnx_path, load_external_data=False)
+    opt_seq_lens = opt_seq_lens or {}
+
+    min_shapes, opt_shapes, max_shapes = {}, {}, {}
+
+    for inp in model.graph.input:
+        name = inp.name
+        dims = inp.type.tensor_type.shape.dim
+
+        min_shape, opt_shape, max_shape = [], [], []
+        for i, d in enumerate(dims):
+            if d.dim_value > 0:
+                # Fixed dimension
+                min_shape.append(d.dim_value)
+                opt_shape.append(d.dim_value)
+                max_shape.append(d.dim_value)
+            else:
+                dim_name = d.dim_param if d.dim_param else f"dim_{i}"
+                if i == 0 and (dim_name == "batch_size" or i == 0):
+                    # Batch dimension
+                    min_shape.append(1)
+                    opt_shape.append(1)
+                    max_shape.append(max_batch)
+                elif dim_name in opt_seq_lens:
+                    opt_val = opt_seq_lens[dim_name]
+                    min_shape.append(1)
+                    opt_shape.append(opt_val)
+                    max_shape.append(max(opt_val * 2, 512))
+                else:
+                    # Unknown dynamic dim — use wide range
+                    min_shape.append(1)
+                    opt_shape.append(256)
+                    max_shape.append(512)
+
+        min_shapes[name] = tuple(min_shape)
+        opt_shapes[name] = tuple(opt_shape)
+        max_shapes[name] = tuple(max_shape)
+
+    return min_shapes, opt_shapes, max_shapes
+
+
+# ============================================================
+# Engine Builder
+# ============================================================
 
 
 def build_engine(
@@ -34,8 +150,7 @@ def build_engine(
     opt_shapes: dict = None,
     max_shapes: dict = None,
 ):
-    """
-    Build TensorRT engine from ONNX model.
+    """Build TensorRT engine from ONNX model.
 
     Args:
         onnx_path: Path to ONNX model
@@ -55,13 +170,23 @@ def build_engine(
     logger.info(f"Workspace: {workspace_mb} MB")
     logger.info("=" * 80)
 
-    # Create TensorRT logger
     TRT_LOGGER = trt.Logger(trt.Logger.VERBOSE)
 
     # Create builder and network
     logger.info("\n[Step 1/5] Creating TensorRT builder...")
     builder = trt.Builder(TRT_LOGGER)
-    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+
+    # Use STRONGLY_TYPED network when available (TRT 10.x+).
+    # With STRONGLY_TYPED, tensor types are inferred from the ONNX model and
+    # TRT won't silently change precision. EXPLICIT_BATCH is deprecated in TRT 10.x.
+    use_strongly_typed = hasattr(trt.NetworkDefinitionCreationFlag, "STRONGLY_TYPED")
+    if use_strongly_typed:
+        network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+        logger.info("Using STRONGLY_TYPED network (TRT 10.x+)")
+    else:
+        network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+        logger.info("Using EXPLICIT_BATCH network (TRT 9.x fallback)")
+    network = builder.create_network(network_flags)
     parser = trt.OnnxParser(network, TRT_LOGGER)
 
     # Parse ONNX model
@@ -72,7 +197,6 @@ def build_engine(
             logger.error(parser.get_error(error))
         raise RuntimeError("ONNX parsing failed")
 
-    # Parser successful. Network is loaded
     logger.info(f"Network inputs: {network.num_inputs}")
     for i in range(network.num_inputs):
         inp = network.get_input(i)
@@ -87,28 +211,34 @@ def build_engine(
     logger.info("\n[Step 3/5] Configuring builder...")
     config = builder.create_builder_config()
 
-    # Enable detailed profiling for engine inspection
-    # This allows get_layer_information() to return layer types, precisions, tactics, etc.
     config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
     logger.info("Enabled DETAILED profiling verbosity for engine inspection")
 
-    # Set workspace
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_mb * (1024**2))
 
-    # Set precision
-    if precision == "fp16":
-        config.set_flag(trt.BuilderFlag.FP16)
-        logger.info("Enabled FP16 mode")
-    elif precision == "bf16":
-        config.set_flag(trt.BuilderFlag.BF16)
-        logger.info("Enabled BF16 mode")
-    elif precision == "fp8":
-        config.set_flag(trt.BuilderFlag.FP8)
-        logger.info("Enabled FP8 mode")
-    elif precision == "fp32":
-        logger.info("Using FP32 (default precision)")
+    if use_strongly_typed:
+        # With STRONGLY_TYPED, precision comes from the ONNX model's tensor types.
+        # No need to set BF16/FP16 builder flags — they're implicit in the model.
+        # For FP8, the Q/DQ nodes in the ONNX model dictate FP8 layers.
+        logger.info(
+            f"Precision '{precision}' enforced by STRONGLY_TYPED network (types from ONNX model)"
+        )
     else:
-        raise ValueError(f"Unknown precision: {precision}")
+        # Weak-typed fallback: explicitly set precision flags
+        if precision == "fp16":
+            config.set_flag(trt.BuilderFlag.FP16)
+            logger.info("Enabled FP16 mode")
+        elif precision == "bf16":
+            config.set_flag(trt.BuilderFlag.BF16)
+            logger.info("Enabled BF16 mode")
+        elif precision == "fp8":
+            config.set_flag(trt.BuilderFlag.FP8)
+            config.set_flag(trt.BuilderFlag.BF16)
+            logger.info("Enabled FP8 + BF16 mode")
+        elif precision == "fp32":
+            logger.info("Using FP32 (default precision)")
+        else:
+            raise ValueError(f"Unknown precision: {precision}")
 
     # Set optimization profiles for dynamic shapes
     if min_shapes and opt_shapes and max_shapes:
@@ -148,7 +278,7 @@ def build_engine(
 
     # Save engine
     logger.info(f"\nSaving engine to {engine_path}...")
-    os.makedirs(os.path.dirname(engine_path), exist_ok=True)
+    os.makedirs(os.path.dirname(engine_path) or ".", exist_ok=True)
     with open(engine_path, "wb") as f:
         f.write(serialized_engine)
 
@@ -164,11 +294,148 @@ def build_engine(
     logger.info(f"Precision: {precision.upper()}")
     logger.info("=" * 80)
 
+    return engine_path
+
+
+# ============================================================
+# Full Pipeline Builder
+# ============================================================
+
+
+def build_full_pipeline(onnx_dir, engine_dir, precision="bf16", workspace_mb=8192):
+    """Build all TRT engines for the full pipeline.
+
+    Shape profiles are automatically derived from the ONNX models.
+    Dynamic sequence dimensions use hints based on typical inference shapes.
+
+    Args:
+        onnx_dir: Directory containing exported ONNX models
+        engine_dir: Directory to save TRT engines
+        precision: Precision mode
+        workspace_mb: Workspace size in MB
+    """
+    os.makedirs(engine_dir, exist_ok=True)
+
+    # Load sequence length hints from export metadata if available,
+    # otherwise fall back to hardcoded defaults for GR1 single-view.
+    metadata_path = os.path.join(onnx_dir, "export_metadata.json")
+    if os.path.exists(metadata_path):
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+        seq_hints = {
+            "sa_seq_len": metadata["sa_seq_len"],
+            "vl_seq_len": metadata["vl_seq_len"],
+            "sequence_length": metadata["llm_seq_len"],
+        }
+        logger.info(f"Loaded shape hints from {metadata_path}: {seq_hints}")
+    else:
+        seq_hints = {
+            "sa_seq_len": 51,  # 1 state + action_horizon
+            "vl_seq_len": 280,  # typical backbone output seq_len
+            "sequence_length": 280,  # LLM seq_len
+        }
+        logger.warning(
+            f"No export_metadata.json found in {onnx_dir}, using default hints: {seq_hints}"
+        )
+
+    # Components: (name, onnx_file, engine_file)
+    components = [
+        ("ViT", "vit_bf16.onnx", "vit_bf16.engine"),
+        ("LLM", "llm_bf16.onnx", "llm_bf16.engine"),
+        ("State Encoder", "state_encoder.onnx", "state_encoder.engine"),
+        ("Action Encoder", "action_encoder.onnx", "action_encoder.engine"),
+        ("DiT", "dit_bf16.onnx", "dit_bf16.engine"),
+        ("Action Decoder", "action_decoder.onnx", "action_decoder.engine"),
+    ]
+
+    results = []
+
+    for name, onnx_file, engine_file in components:
+        onnx_path = os.path.join(onnx_dir, onnx_file)
+
+        if not os.path.exists(onnx_path):
+            logger.warning(f"Skipping {name}: ONNX file not found at {onnx_path}")
+            continue
+
+        logger.info(f"\n{'#' * 80}")
+        logger.info(f"# Building {name} engine")
+        logger.info(f"{'#' * 80}")
+
+        engine_path = os.path.join(engine_dir, engine_file)
+
+        try:
+            # Derive shapes from the ONNX model itself
+            min_shapes, opt_shapes, max_shapes = derive_shapes_with_hint(
+                onnx_path, opt_seq_lens=seq_hints
+            )
+
+            logger.info(f"  Auto-derived shape profiles for {name}:")
+            for input_name in opt_shapes:
+                logger.info(
+                    f"    {input_name}: min={min_shapes[input_name]} "
+                    f"opt={opt_shapes[input_name]} max={max_shapes[input_name]}"
+                )
+
+            build_engine(
+                onnx_path=onnx_path,
+                engine_path=engine_path,
+                precision=precision,
+                workspace_mb=workspace_mb,
+                min_shapes=min_shapes,
+                opt_shapes=opt_shapes,
+                max_shapes=max_shapes,
+            )
+            results.append((name, engine_path, "SUCCESS"))
+        except Exception as e:
+            logger.error(f"Failed to build {name} engine: {e}")
+            results.append((name, engine_path, f"FAILED: {e}"))
+
+    # Print summary
+    logger.info("\n" + "=" * 80)
+    logger.info("FULL PIPELINE BUILD SUMMARY")
+    logger.info("=" * 80)
+    for name, path, status in results:
+        logger.info(f"  {name:20s} -> {status}")
+    logger.info("=" * 80)
+
+
+# ============================================================
+# Main
+# ============================================================
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Build TensorRT engine from ONNX")
-    parser.add_argument("--onnx", type=str, required=True, help="Path to ONNX model")
-    parser.add_argument("--engine", type=str, required=True, help="Path to save TensorRT engine")
+    parser = argparse.ArgumentParser(description="Build TensorRT engines from ONNX models")
+
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="single",
+        choices=["single", "full_pipeline"],
+        help="Build mode: 'single' (one engine) or 'full_pipeline' (all engines)",
+    )
+
+    # Single engine mode
+    parser.add_argument("--onnx", type=str, default=None, help="Path to ONNX model (single mode)")
+    parser.add_argument(
+        "--engine", type=str, default=None, help="Path to save TensorRT engine (single mode)"
+    )
+
+    # Full pipeline mode
+    parser.add_argument(
+        "--onnx_dir",
+        type=str,
+        default="./groot_n1d6_onnx",
+        help="Directory with ONNX models (full_pipeline mode)",
+    )
+    parser.add_argument(
+        "--engine_dir",
+        type=str,
+        default="./groot_n1d6_engines",
+        help="Directory to save engines (full_pipeline mode)",
+    )
+
+    # Shared options
     parser.add_argument(
         "--precision",
         type=str,
@@ -182,44 +449,28 @@ def main():
 
     args = parser.parse_args()
 
-    # Define shapes for your specific model (from export)
-    min_shapes = None
-    opt_shapes = None
-    max_shapes = None
+    if args.mode == "full_pipeline":
+        build_full_pipeline(
+            onnx_dir=args.onnx_dir,
+            engine_dir=args.engine_dir,
+            precision=args.precision,
+            workspace_mb=args.workspace,
+        )
+    else:
+        if not args.onnx or not args.engine:
+            parser.error("--onnx and --engine are required in single mode")
 
-    # Establish Dynamic Shapes to handle variable seq lengths
-    # Based on captured inputs but with ranges to handle variations
-    min_shapes = {
-        "sa_embs": (1, 1, 1536),  # Min: 1 token
-        "vl_embs": (1, 1, 2048),  # Min: 1 token
-        "timestep": (1,),
-        "image_mask": (1, 1),  # Min: 1 token
-        "backbone_attention_mask": (1, 1),  # Min: 1 token
-    }
-    opt_shapes = {
-        "sa_embs": (1, 51, 1536),  # Typical: 51 tokens
-        "vl_embs": (1, 122, 2048),  # Typical: 122 tokens
-        "timestep": (1,),
-        "image_mask": (1, 122),  # Typical: 122 tokens
-        "backbone_attention_mask": (1, 122),  # Typical: 122 tokens
-    }
-    max_shapes = {
-        "sa_embs": (1, 256, 1536),  # Max: 256 tokens (generous)
-        "vl_embs": (1, 512, 2048),  # Max: 512 tokens (generous)
-        "timestep": (1,),
-        "image_mask": (1, 512),  # Max: 512 tokens
-        "backbone_attention_mask": (1, 512),  # Max: 512 tokens
-    }
-
-    build_engine(
-        onnx_path=args.onnx,
-        engine_path=args.engine,
-        precision=args.precision,
-        workspace_mb=args.workspace,
-        min_shapes=min_shapes,
-        opt_shapes=opt_shapes,
-        max_shapes=max_shapes,
-    )
+        # Auto-derive shapes from the ONNX model
+        min_shapes, opt_shapes, max_shapes = derive_shapes_with_hint(args.onnx)
+        build_engine(
+            onnx_path=args.onnx,
+            engine_path=args.engine,
+            precision=args.precision,
+            workspace_mb=args.workspace,
+            min_shapes=min_shapes,
+            opt_shapes=opt_shapes,
+            max_shapes=max_shapes,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/deployment/eval_trt_robocasa.sh
+++ b/scripts/deployment/eval_trt_robocasa.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# ============================================================================
+# RoboCasa Evaluation: Compare PyTorch Eager vs TRT BF16 vs TRT FP8
+#
+# Runs the full RoboCasa 24-task GR1 tabletop evaluation suite for each
+# inference backend and produces a comparison summary.
+#
+# Prerequisites:
+#   - BF16 TRT engines built: bash scripts/deployment/run_trt_pipeline.sh build_bf16
+#   - FP8 TRT engines built:  bash scripts/deployment/run_trt_pipeline.sh build_fp8
+#   - RoboCasa environment set up (robocasa_uv venv)
+#
+# Usage:
+#   bash scripts/deployment/eval_trt_robocasa.sh all       # ~10 hours
+#   bash scripts/deployment/eval_trt_robocasa.sh eager      # ~3-4 hours
+#   bash scripts/deployment/eval_trt_robocasa.sh bf16
+#   bash scripts/deployment/eval_trt_robocasa.sh fp8
+#   bash scripts/deployment/eval_trt_robocasa.sh compare    # compare existing results
+#   bash scripts/deployment/eval_trt_robocasa.sh quick      # smoke test (~10 min)
+# ============================================================================
+
+set -euo pipefail
+
+# ---- Configuration (override via environment variables) ----
+MODEL_PATH="${MODEL_PATH:-nvidia/GR00T-N1.6-3B}"
+EMBODIMENT="${EMBODIMENT:-GR1}"
+PORT="${PORT:-5556}"
+HOST="${HOST:-127.0.0.1}"
+BF16_ENGINE_DIR="${BF16_ENGINE_DIR:-./groot_n1d6_engines}"
+FP8_ENGINE_DIR="${FP8_ENGINE_DIR:-./groot_n1d6_engines_fp8}"
+RESULTS_DIR="${RESULTS_DIR:-./eval_results}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MAIN_REPO="${MAIN_REPO:-/xiaotongc/gr00t-internal}"
+SERVER_SCRIPT="${PROJECT_ROOT}/gr00t/eval/run_gr00t_server.py"
+
+# Eval parameters
+N_EPISODES="${N_EPISODES:-20}"
+N_ENVS="${N_ENVS:-5}"
+MAX_STEPS="${MAX_STEPS:-720}"
+N_ACTION_STEPS="${N_ACTION_STEPS:-8}"
+
+# RoboCasa rollout client — uses the robocasa_uv venv from main repo
+ROLLOUT_PYTHON="${MAIN_REPO}/gr00t/eval/sim/robocasa-gr1-tabletop-tasks/robocasa_uv/.venv/bin/python"
+ROLLOUT_SCRIPT="${MAIN_REPO}/gr00t/eval/rollout_policy.py"
+
+# ---- 24 RoboCasa GR1 Tabletop Tasks ----
+TASKS=(
+    "gr1_unified/PnPBottleToCabinetClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PnPCanToDrawerClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PnPCupToDrawerClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PnPMilkToMicrowaveClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PnPPotatoToMicrowaveClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PnPWineToCabinetClose_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromCuttingboardToBasketSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromCuttingboardToCardboardboxSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromCuttingboardToPanSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromCuttingboardToPotSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromCuttingboardToTieredbasketSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlacematToBasketSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlacematToBowlSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlacematToPlateSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlacematToTieredshelfSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlateToBowlSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlateToCardboardboxSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlateToPanSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromPlateToPlateSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromTrayToCardboardboxSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromTrayToPlateSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromTrayToPotSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromTrayToTieredbasketSplitA_GR1ArmsAndWaistFourierHands_Env"
+    "gr1_unified/PosttrainPnPNovelFromTrayToTieredshelfSplitA_GR1ArmsAndWaistFourierHands_Env"
+)
+
+# ---- Helpers ----
+
+mkdir -p "$RESULTS_DIR"
+
+wait_for_server() {
+    local max_wait=180
+    local waited=0
+    echo "Waiting for server on $HOST:$PORT..."
+    while ! uv run python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('$HOST', $PORT)); s.close()" 2>/dev/null; do
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$max_wait" ]; then
+            echo "ERROR: Server did not start within ${max_wait}s"
+            return 1
+        fi
+    done
+    echo "Server is ready (waited ${waited}s)"
+}
+
+kill_server() {
+    echo "Stopping server..."
+    if [ -n "${SERVER_PID:-}" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    # Also kill any lingering server on our port
+    lsof -ti :"$PORT" 2>/dev/null | xargs -r kill 2>/dev/null || true
+    sleep 2
+}
+
+run_robocasa_eval() {
+    # Run all 24 RoboCasa tasks against a running server.
+    # Results are written to the given file.
+    local results_file="$1"
+    local total_tasks=${#TASKS[@]}
+    local completed=0
+    local sum_success=0
+
+    echo "========================================" | tee "$results_file"
+    echo "RoboCasa GR1 Tabletop Tasks Evaluation" | tee -a "$results_file"
+    echo "Date: $(date)" | tee -a "$results_file"
+    echo "N_EPISODES=$N_EPISODES, N_ENVS=$N_ENVS, PORT=$PORT" | tee -a "$results_file"
+    echo "========================================" | tee -a "$results_file"
+
+    for TASK in "${TASKS[@]}"; do
+        completed=$((completed + 1))
+        echo "" | tee -a "$results_file"
+        echo "[$completed/$total_tasks] Running: $TASK" | tee -a "$results_file"
+        echo "Start time: $(date)" | tee -a "$results_file"
+
+        OUTPUT=$($ROLLOUT_PYTHON "$ROLLOUT_SCRIPT" \
+            --n_episodes "$N_EPISODES" \
+            --policy_client_host "$HOST" \
+            --policy_client_port "$PORT" \
+            --max_episode_steps "$MAX_STEPS" \
+            --env_name "$TASK" \
+            --n_action_steps "$N_ACTION_STEPS" \
+            --n_envs "$N_ENVS" 2>&1) || true
+
+        # Extract success rate
+        SR=$(echo "$OUTPUT" | grep "success rate:" | tail -1 | awk '{print $NF}')
+        RESULTS_LINE=$(echo "$OUTPUT" | grep "results:" | tail -1)
+
+        if [ -n "$SR" ]; then
+            echo "  Success rate: $SR" | tee -a "$results_file"
+            sum_success=$(awk "BEGIN {print $sum_success + $SR}")
+        else
+            echo "  ERROR: Could not extract success rate" | tee -a "$results_file"
+            echo "  Last 5 lines of output:" | tee -a "$results_file"
+            echo "$OUTPUT" | tail -5 | tee -a "$results_file"
+        fi
+
+        if [ -n "$RESULTS_LINE" ]; then
+            echo "  $RESULTS_LINE" | tee -a "$results_file"
+        fi
+
+        echo "End time: $(date)" | tee -a "$results_file"
+        echo "----------------------------------------" | tee -a "$results_file"
+    done
+
+    local avg
+    avg=$(awk "BEGIN {printf \"%.4f\", $sum_success / $total_tasks}")
+    echo "" | tee -a "$results_file"
+    echo "========================================" | tee -a "$results_file"
+    echo "FINAL AVERAGE SUCCESS RATE: $avg" | tee -a "$results_file"
+    echo "========================================" | tee -a "$results_file"
+}
+
+run_experiment() {
+    local name="$1"
+    local extra_args="${2:-}"
+    local results_file="${RESULTS_DIR}/robocasa_eval_${name}.txt"
+    local server_log="${RESULTS_DIR}/server_${name}.log"
+
+    echo ""
+    echo "========================================================================"
+    echo "  Experiment: $name"
+    echo "  Results: $results_file"
+    echo "  Server log: $server_log"
+    echo "========================================================================"
+
+    # Kill any existing server
+    kill_server
+
+    # Start server in background
+    echo "Starting server ($name)..."
+    # shellcheck disable=SC2086
+    uv run python "$SERVER_SCRIPT" \
+        --model_path "$MODEL_PATH" \
+        --embodiment_tag "$EMBODIMENT" \
+        --port "$PORT" \
+        --host "$HOST" \
+        --use_sim_policy_wrapper \
+        $extra_args \
+        > "$server_log" 2>&1 &
+    SERVER_PID=$!
+    echo "  Server PID: $SERVER_PID"
+
+    # Wait for server to be ready
+    if ! wait_for_server; then
+        echo "ERROR: Server failed to start. Check $server_log"
+        kill_server
+        return 1
+    fi
+
+    # Run evaluation
+    echo "Running RoboCasa evaluation (${#TASKS[@]} tasks, $N_EPISODES episodes each)..."
+    local start_time
+    start_time=$(date +%s)
+
+    run_robocasa_eval "$results_file"
+
+    local end_time
+    end_time=$(date +%s)
+    local duration=$(( end_time - start_time ))
+    echo "  Evaluation completed in $((duration / 60))m $((duration % 60))s"
+
+    # Stop server
+    kill_server
+
+    echo "  Results saved to: $results_file"
+    echo ""
+}
+
+compare_results() {
+    echo ""
+    echo "========================================================================"
+    echo "  COMPARISON SUMMARY"
+    echo "========================================================================"
+    echo ""
+
+    local summary_file="${RESULTS_DIR}/comparison_summary.txt"
+    {
+        echo "RoboCasa TRT Evaluation Comparison"
+        echo "Date: $(date)"
+        echo "Model: $MODEL_PATH"
+        echo "N_EPISODES: $N_EPISODES"
+        echo ""
+        printf "%-15s  %s\n" "Backend" "Avg Success Rate"
+        echo "-------------------------------"
+
+        for name in eager bf16 fp8; do
+            local results_file="${RESULTS_DIR}/robocasa_eval_${name}.txt"
+            if [ -f "$results_file" ]; then
+                local avg
+                avg=$(grep "FINAL AVERAGE SUCCESS RATE" "$results_file" | awk '{print $NF}' || echo "N/A")
+                printf "%-15s  %s\n" "$name" "$avg"
+            else
+                printf "%-15s  %s\n" "$name" "(not run)"
+            fi
+        done
+
+        echo ""
+        echo "Per-task breakdown:"
+        echo ""
+
+        for name in eager bf16 fp8; do
+            local results_file="${RESULTS_DIR}/robocasa_eval_${name}.txt"
+            if [ -f "$results_file" ]; then
+                echo "--- $name ---"
+                grep "Success rate:" "$results_file" || true
+                echo ""
+            fi
+        done
+    } | tee "$summary_file"
+
+    echo "Summary saved to: $summary_file"
+}
+
+# ---- Main ----
+
+COMMAND="${1:-all}"
+
+case "$COMMAND" in
+    eager)
+        run_experiment "eager" ""
+        ;;
+    bf16)
+        if [ ! -d "$BF16_ENGINE_DIR" ]; then
+            echo "ERROR: BF16 engine dir not found: $BF16_ENGINE_DIR"
+            echo "Run: bash scripts/deployment/run_trt_pipeline.sh build_bf16"
+            exit 1
+        fi
+        run_experiment "bf16" "--trt_engine_path $BF16_ENGINE_DIR --trt_mode full_pipeline"
+        ;;
+    fp8)
+        if [ ! -d "$FP8_ENGINE_DIR" ]; then
+            echo "ERROR: FP8 engine dir not found: $FP8_ENGINE_DIR"
+            echo "Run: bash scripts/deployment/run_trt_pipeline.sh export_fp8 && bash scripts/deployment/run_trt_pipeline.sh build_fp8"
+            exit 1
+        fi
+        run_experiment "fp8" "--trt_engine_path $FP8_ENGINE_DIR --trt_mode full_pipeline"
+        ;;
+    all)
+        echo "Running all 3 experiments: eager -> bf16 -> fp8"
+        echo "This will take ~10 hours (24 tasks x 20 episodes x 3 backends)."
+        echo ""
+
+        run_experiment "eager" ""
+
+        if [ -d "$BF16_ENGINE_DIR" ]; then
+            run_experiment "bf16" "--trt_engine_path $BF16_ENGINE_DIR --trt_mode full_pipeline"
+        else
+            echo "SKIP: BF16 engines not found at $BF16_ENGINE_DIR"
+        fi
+
+        if [ -d "$FP8_ENGINE_DIR" ]; then
+            run_experiment "fp8" "--trt_engine_path $FP8_ENGINE_DIR --trt_mode full_pipeline"
+        else
+            echo "SKIP: FP8 engines not found at $FP8_ENGINE_DIR"
+        fi
+
+        compare_results
+        ;;
+    compare)
+        compare_results
+        ;;
+    quick)
+        echo "Running quick smoke test (2 episodes, 1 env)"
+        N_EPISODES=2
+        N_ENVS=1
+        run_experiment "eager" ""
+        if [ -d "$BF16_ENGINE_DIR" ]; then
+            run_experiment "bf16" "--trt_engine_path $BF16_ENGINE_DIR --trt_mode full_pipeline"
+        fi
+        compare_results
+        ;;
+    *)
+        echo "Usage: $0 {all|eager|bf16|fp8|compare|quick}"
+        echo ""
+        echo "  all      Run all 3 experiments and compare (~10 hours)"
+        echo "  eager    Run PyTorch eager baseline only (~3-4 hours)"
+        echo "  bf16     Run TRT BF16 only (~3-4 hours)"
+        echo "  fp8      Run TRT FP8 only (~3-4 hours)"
+        echo "  compare  Compare existing results (instant)"
+        echo "  quick    Quick smoke test with 2 episodes (~10 min)"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Done!"

--- a/scripts/deployment/export_onnx_n1d6.py
+++ b/scripts/deployment/export_onnx_n1d6.py
@@ -1,20 +1,32 @@
 #!/usr/bin/env python3
 """
-Export GrootN1d6 model components to ONNX for TensorRT optimization.
+Export GR00T N1.6 model components to ONNX for TensorRT optimization.
 
-This script exports the DiT (Diffusion Transformer)
-of the GrootN1d6 model to ONNX format for TensorRT conversion.
+Supports two export modes:
+- dit_only: Export only the DiT model (backward compatible)
+- full_pipeline: Export LLM + State Encoder + Action Encoder + DiT + Action Decoder
 
 Usage:
-    python export_onnx_n1d6.py \
-        --model_path /path/to/checkpoint \
-        --dataset_path /path/to/dataset \
+    # DiT only (default):
+    python scripts/deployment/export_onnx_n1d6.py \
+        --model_path nvidia/GR00T-N1.6-3B \
+        --dataset_path demo_data/gr1.PickNPlace \
         --output_dir ./groot_n1d6_onnx
+
+    # Full pipeline:
+    python scripts/deployment/export_onnx_n1d6.py \
+        --model_path nvidia/GR00T-N1.6-3B \
+        --dataset_path demo_data/gr1.PickNPlace \
+        --output_dir ./groot_n1d6_onnx \
+        --export_mode full_pipeline
 """
 
 import argparse
+import copy
+import json
 import logging
 import os
+import sys
 from typing import Any
 
 from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
@@ -23,7 +35,17 @@ from gr00t.data.embodiment_tags import EmbodimentTag
 from gr00t.policy.gr00t_policy import Gr00tPolicy
 import numpy as np
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 import torch.onnx
+
+
+# Ensure scripts/deployment/ is on sys.path for sibling module imports
+_DEPLOY_DIR = os.path.dirname(os.path.abspath(__file__))
+if _DEPLOY_DIR not in sys.path:
+    sys.path.insert(0, _DEPLOY_DIR)
+
+from accuracy_thresholds import VIT_WRAPPER_COSINE_MIN  # noqa: E402  # isort: skip
 
 
 # Set up logging
@@ -31,10 +53,13 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
+# ============================================================
+# Input Capture Helpers
+# ============================================================
+
+
 class DiTInputCapture:
-    """
-    Helper class to capture DiT forward pass inputs during inference.
-    """
+    """Capture DiT forward pass inputs during inference."""
 
     def __init__(self):
         self.captured = False
@@ -58,18 +83,21 @@ class DiTInputCapture:
                 self.backbone_attention_mask = bb_mask.detach().cpu().clone()
 
             self.captured = True
-            logger.info(" Captured DiT inputs:")
-            logger.info(f"  sa_embs shape: {self.sa_embs.shape}")
-            logger.info(f"  vl_embs shape: {self.vl_embs.shape}")
-            logger.info(
-                f"  timestep shape: {self.timestep.shape if self.timestep is not None else 'None'}"
-            )
-            logger.info(
-                f"  image_mask shape: {self.image_mask.shape if self.image_mask is not None else 'None'}"
-            )
-            logger.info(
-                f"  backbone_attention_mask shape: {self.backbone_attention_mask.shape if self.backbone_attention_mask is not None else 'None'}"
-            )
+            logger.info("  Captured DiT inputs:")
+            logger.info(f"    sa_embs shape: {self.sa_embs.shape}")
+            logger.info(f"    vl_embs shape: {self.vl_embs.shape}")
+            logger.info(f"    timestep shape: {self.timestep.shape}")
+            if self.image_mask is not None:
+                logger.info(f"    image_mask shape: {self.image_mask.shape}")
+            if self.backbone_attention_mask is not None:
+                logger.info(
+                    f"    backbone_attention_mask shape: {self.backbone_attention_mask.shape}"
+                )
+
+
+# ============================================================
+# Observation Helpers
+# ============================================================
 
 
 def parse_observation_gr00t(
@@ -93,81 +121,667 @@ def parse_observation_gr00t(
 
 
 def prepare_observation(policy, dataset, traj_idx=0):
-    """
-    Prepare a single observation for inference.
-
-    Args:
-        policy: Loaded Gr00tPolicy
-        dataset: Dataset loader
-        traj_idx: Trajectory index to use
-
-    Returns:
-        Observation dictionary ready for policy.get_action()
-    """
+    """Prepare a single observation for inference."""
     logger.info(f"\nPreparing observation from trajectory {traj_idx}...")
 
-    # Load trajectory
     traj = dataset[traj_idx]
-
-    # Get modality configs
     modality_configs = policy.get_modality_config()
 
-    # Extract first step
     data_point = extract_step_data(
         traj,
-        0,  # First timestep
+        0,
         modality_configs=modality_configs,
         embodiment_tag=policy.embodiment_tag,
     )
 
-    # Build observation dict
     observation = {}
     for key, value in data_point.states.items():
         observation[f"state.{key}"] = value
-
     for key, value in data_point.images.items():
         observation[f"video.{key}"] = np.array(value)
-
     for key in modality_configs["language"].modality_keys:
         observation[key] = data_point.text
 
-    # Parse observation to expected format
     parsed_obs = parse_observation_gr00t(observation, modality_configs)
-
-    logger.info(" Observation prepared")
+    logger.info("  Observation prepared")
     return parsed_obs
+
+
+# ============================================================
+# ViT (Siglip2) ONNX-Exportable Wrappers
+# ============================================================
+
+
+class Siglip2AttentionOpt(nn.Module):
+    """ONNX-exportable attention for Siglip2 (no RoPE, no windowed attention).
+
+    Uses F.scaled_dot_product_attention (SDPA) for normal inference — SDPA
+    selects the most efficient kernel (flash, memory-efficient, or math) and
+    produces numerically closer results to the flash_attention_2 used by the
+    original model, reducing wrapper-vs-original drift.
+
+    During ONNX export, falls back to manual matmul+softmax since the legacy
+    ONNX exporter cannot trace SDPA (ComplexDouble type error).
+    """
+
+    def __init__(self, original_attn):
+        super().__init__()
+        self.embed_dim = original_attn.embed_dim
+        self.num_heads = original_attn.num_heads
+        self.head_dim = original_attn.head_dim
+        self.scale = original_attn.scale
+
+        self.q_proj = original_attn.q_proj
+        self.k_proj = original_attn.k_proj
+        self.v_proj = original_attn.v_proj
+        self.out_proj = original_attn.out_proj
+
+    def forward(self, hidden_states):
+        B, N, C = hidden_states.shape
+        q = self.q_proj(hidden_states).view(B, N, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(hidden_states).view(B, N, self.num_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(hidden_states).view(B, N, self.num_heads, self.head_dim).transpose(1, 2)
+
+        if torch.onnx.is_in_onnx_export():
+            attn = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+            attn = F.softmax(attn, dim=-1, dtype=torch.float32).to(q.dtype)
+            out = torch.matmul(attn, v)
+        else:
+            out = F.scaled_dot_product_attention(q, k, v, scale=self.scale)
+
+        out = out.transpose(1, 2).reshape(B, N, C)
+        return self.out_proj(out)
+
+
+class Siglip2EncoderLayerOpt(nn.Module):
+    """ONNX-exportable encoder layer for Siglip2."""
+
+    def __init__(self, original_layer):
+        super().__init__()
+        self.layer_norm1 = original_layer.layer_norm1
+        self.self_attn = Siglip2AttentionOpt(original_layer.self_attn)
+        self.layer_norm2 = original_layer.layer_norm2
+        self.mlp = original_layer.mlp
+
+    def forward(self, hidden_states):
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Siglip2EncoderOpt(nn.Module):
+    """ONNX-exportable encoder for Siglip2 (no RoPE, no win_meta_list)."""
+
+    def __init__(self, original_encoder):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [Siglip2EncoderLayerOpt(layer) for layer in original_encoder.layers]
+        )
+
+    def forward(self, hidden_states):
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class Siglip2VisionTransformerOpt(nn.Module):
+    """ONNX-exportable wrapper for Siglip2 ViT (fixed resolution).
+
+    Pre-computes all metadata-dependent operations (window reordering,
+    positional embeddings, reverse mapping) as static buffers. This avoids
+    Python-level logic (lists, dicts) that ONNX cannot export.
+
+    The image_size is determined from actual inference (e.g. 252 for GR1)
+    since Eagle's smart_resize() may adjust the resolution at runtime.
+
+    Requires: use_rope=False and use_windows_attn=False in the model config.
+    """
+
+    def __init__(self, original_vit, image_size):
+        super().__init__()
+        config = original_vit.config
+        patch_size = config.patch_size
+        assert image_size % patch_size == 0, (
+            f"image_size ({image_size}) must be divisible by patch_size ({patch_size})"
+        )
+        num_patches_per_side = image_size // patch_size
+
+        # Validate assumptions
+        assert not config.use_rope, "ViT ONNX export requires use_rope=False"
+        assert not config.use_windows_attn, "ViT ONNX export requires use_windows_attn=False"
+
+        # Copy core submodules (weights are shared, not cloned)
+        self.patch_embedding = original_vit.embeddings.patch_embedding
+        self.encoder = Siglip2EncoderOpt(original_vit.encoder)
+        self.post_layernorm = original_vit.post_layernorm
+
+        # Pre-compute static positional embeddings for the target resolution
+        embeddings_module = original_vit.embeddings
+        pos_emb_size = embeddings_module.position_embedding_size  # sqrt(num_patches)
+        pos_weight = embeddings_module.position_embedding.weight.reshape(
+            pos_emb_size, pos_emb_size, -1
+        )
+
+        spatial_shapes = torch.tensor([[num_patches_per_side, num_patches_per_side]])
+        with torch.no_grad():
+            # resize_positional_embeddings: (pos_size, pos_size, C) -> (1, H*W, C)
+            # Access the static method from the embeddings module's class
+            static_pos = embeddings_module.resize_positional_embeddings(pos_weight, spatial_shapes)
+        self.register_buffer("static_position_embeddings", static_pos)
+
+        # Pre-compute window reordering and reverse mapping
+        # Run original embeddings once with a dummy image to capture the indices
+        device = next(original_vit.parameters()).device
+        dtype = next(original_vit.parameters()).dtype
+        dummy_images = [torch.randn(1, 3, image_size, image_size, device=device, dtype=dtype)]
+
+        with torch.no_grad():
+            windows_tensor, win_meta_list, _, reverse_mapping = embeddings_module(dummy_images)
+
+        # Build forward mapping: original patch order → windowed patch order.
+        #
+        # reverse_mapping[orig_idx] = windowed_idx  (from embeddings code)
+        # Original ViT uses: output[:, orig_idx] = hidden[:, reverse_mapping[orig_idx]]
+        #   = hidden[:, windowed_idx]  →  restores original order from windowed order.
+        #
+        # We need forward_mapping such that:
+        #   output[:, windowed_idx] = input[:, forward_mapping[windowed_idx]]
+        #   = input[:, orig_idx]  →  reorders original to windowed order.
+        #
+        # So forward_mapping[windowed_idx] = orig_idx (the inverse of reverse_mapping).
+        total_patches = num_patches_per_side * num_patches_per_side
+        forward_mapping = torch.zeros(total_patches, dtype=torch.long, device=device)
+        for orig_idx in range(total_patches):
+            windowed_idx = reverse_mapping[orig_idx].item()
+            forward_mapping[windowed_idx] = orig_idx
+
+        self.register_buffer("forward_mapping", forward_mapping)
+        self.register_buffer("reverse_mapping", reverse_mapping)
+
+        # Save constants
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.num_patches_per_side = num_patches_per_side
+        self.total_patches = total_patches
+
+    def forward(self, pixel_values):
+        """
+        Args:
+            pixel_values: (B, 3, H, H) single tensor, NOT a list.
+                          H is the image_size passed to __init__ (e.g. 252).
+
+        Returns:
+            vit_embeds: (B, num_patches, 1152)
+        """
+        B = pixel_values.shape[0]
+
+        # 1. Patch embedding: (B, 3, H, H) -> (B*N, ps*ps*3) -> (B*N, 1152)
+        # convert_images_to_patches equivalent using reshape + permute
+        ps = self.patch_size
+        nph = self.num_patches_per_side
+        npw = self.num_patches_per_side
+        # (B, 3, nph, ps, npw, ps)
+        x = pixel_values.reshape(B, 3, nph, ps, npw, ps)
+        # (B, nph, npw, ps, ps, 3) -> (B*nph*npw, ps*ps*3)
+        x = x.permute(0, 2, 4, 3, 5, 1).reshape(B * nph * npw, -1)
+
+        target_dtype = self.patch_embedding.weight.dtype
+        patch_embeds = self.patch_embedding(x.to(dtype=target_dtype))
+        patch_embeds = patch_embeds.reshape(B, self.total_patches, -1)
+
+        # 2. Add pre-computed position embeddings: (1, N, 1152)
+        embeddings = patch_embeds + self.static_position_embeddings
+
+        # 3. Apply window reordering (static index_select)
+        embeddings = torch.index_select(embeddings, 1, self.forward_mapping)
+
+        # 4. Encoder (27 layers, eager attention, no RoPE)
+        hidden_states = self.encoder(embeddings)
+
+        # 5. Post LayerNorm
+        hidden_states = self.post_layernorm(hidden_states)
+
+        # 6. Reverse mapping (restore original patch order)
+        hidden_states = torch.index_select(hidden_states, 1, self.reverse_mapping)
+
+        return hidden_states
+
+
+# ============================================================
+# Export Functions: ViT (Siglip2)
+# ============================================================
+
+
+def export_vit_to_onnx(policy, output_dir, use_bf16=True, captured_image_size=None):
+    """Export Siglip2 ViT to ONNX.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        output_dir: Output directory for ONNX file
+        use_bf16: Whether to export in BF16 precision
+        captured_image_size: Actual image size from inference (e.g. 252).
+                             If None, runs one inference to detect it.
+    """
+    logger.info("\n" + "=" * 80)
+    logger.info("Exporting ViT (Siglip2) to ONNX")
+    logger.info("=" * 80)
+
+    eagle_model = policy.model.backbone.model
+    original_vit = eagle_model.vision_model.vision_model
+
+    logger.info(
+        f"  ViT config: hidden_size={original_vit.config.hidden_size}, "
+        f"num_layers={original_vit.config.num_hidden_layers}, "
+        f"use_rope={original_vit.config.use_rope}, "
+        f"use_windows_attn={original_vit.config.use_windows_attn}"
+    )
+
+    # Determine actual image size if not provided
+    if captured_image_size is None:
+        logger.warning(
+            "  No captured_image_size provided, defaulting to 224. "
+            "Pass captured_image_size for correct resolution."
+        )
+        captured_image_size = 224
+
+    image_size = captured_image_size
+    patch_size = original_vit.config.patch_size
+    nps = image_size // patch_size
+    logger.info(
+        f"  Image size: {image_size}x{image_size} "
+        f"({nps}x{nps} = {nps * nps} patches, patch_size={patch_size})"
+    )
+
+    # Create optimized wrapper
+    opt_model = Siglip2VisionTransformerOpt(original_vit, image_size=image_size).eval().cuda()
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    opt_model = opt_model.to(dtype)
+
+    # Verify numerical equivalence before export
+    logger.info("  Verifying wrapper vs original...")
+    dummy_input = torch.randn(1, 3, image_size, image_size, device="cuda", dtype=dtype)
+    with torch.inference_mode():
+        # Original: expects a list of tensors
+        orig_out = original_vit([dummy_input])
+        orig_embeds = orig_out.last_hidden_state
+
+        # Wrapper: expects a single tensor
+        opt_embeds = opt_model(dummy_input)
+
+    cos_sim = F.cosine_similarity(
+        orig_embeds.float().flatten().unsqueeze(0),
+        opt_embeds.float().flatten().unsqueeze(0),
+    ).item()
+    l1_diff = (orig_embeds.float() - opt_embeds.float()).abs().mean().item()
+    logger.info(f"  Wrapper vs Original: cosine_sim={cos_sim:.6f}, L1_mean={l1_diff:.8f}")
+
+    if cos_sim < VIT_WRAPPER_COSINE_MIN:
+        logger.warning(
+            f"  WARNING: Wrapper output diverges from original! "
+            f"cosine_sim < {VIT_WRAPPER_COSINE_MIN}"
+        )
+
+    # Export to ONNX
+    pixel_values = torch.randn(1, 3, image_size, image_size, dtype=dtype, device="cuda")
+    output_path = os.path.join(output_dir, "vit_bf16.onnx")
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info(f"  pixel_values: {pixel_values.shape} ({pixel_values.dtype})")
+    logger.info(f"  Exporting to {output_path}...")
+
+    with torch.inference_mode():
+        torch.onnx.export(
+            opt_model,
+            (pixel_values,),
+            output_path,
+            input_names=["pixel_values"],
+            output_names=["vit_embeds"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "pixel_values": {0: "batch_size"},
+                "vit_embeds": {0: "batch_size"},
+            },
+        )
+
+    logger.info("  ViT exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# ONNX Verification Helper
+# ============================================================
+
+
+def verify_onnx_export(output_path):
+    """Verify an ONNX export and log file size."""
+    import onnx
+
+    file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
+    logger.info(f"  Model size on disk: {file_size_mb:.2f} MB")
+
+    external_data_path = output_path + ".data"
+    if os.path.exists(external_data_path):
+        external_size_mb = os.path.getsize(external_data_path) / (1024 * 1024)
+        logger.info(f"  External data size: {external_size_mb:.2f} MB")
+        logger.info(f"  Total model size: {file_size_mb + external_size_mb:.2f} MB")
+
+    try:
+        onnx.checker.check_model(output_path)
+        logger.info("  ONNX model is valid!")
+    except ValueError as e:
+        if "too large" in str(e):
+            logger.info("  Model is very large, skipping full validation...")
+            try:
+                tmp_path = output_path + ".tmp"
+                onnx.shape_inference.infer_shapes_path(output_path, tmp_path)
+                os.remove(tmp_path)
+                logger.info("  ONNX model structure verified!")
+            except Exception as e2:
+                logger.warning(f"  Could not fully validate (this is OK): {e2}")
+        else:
+            raise
+
+
+# ============================================================
+# Export Functions: LLM
+# ============================================================
+
+
+def export_llm_to_onnx(policy, seq_len, output_dir, use_bf16=True):
+    """Export the truncated Qwen3 LLM to ONNX with eager attention.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        seq_len: Sequence length from captured inference (for dummy inputs)
+        output_dir: Output directory for ONNX file
+        use_bf16: Whether to export in BF16 precision
+    """
+    logger.info("\n" + "=" * 80)
+    logger.info("Exporting LLM to ONNX")
+    logger.info("=" * 80)
+
+    backbone = policy.model.backbone
+    eagle_model = backbone.model  # Eagle3_VLForConditionalGeneration
+    language_model = eagle_model.language_model  # Qwen3ForCausalLM (truncated)
+    select_layer = backbone.select_layer
+
+    # Create a Qwen3Model with eager attention (no flash)
+    llm_config = copy.deepcopy(language_model.config)
+    llm_config._attn_implementation = "eager"
+    llm_config.num_hidden_layers = select_layer
+
+    logger.info(
+        f"  LLM config: hidden_size={llm_config.hidden_size}, "
+        f"num_layers={llm_config.num_hidden_layers}, "
+        f"attn_implementation={llm_config._attn_implementation}"
+    )
+
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3Model
+
+    class LLMForExport(torch.nn.Module):
+        """Wrapper that returns last hidden state instead of logits.
+
+        Replaces the internal _update_causal_mask to avoid COMPLEX128 type casts
+        that TensorRT's ONNX parser cannot handle.
+        """
+
+        def __init__(self, config):
+            super().__init__()
+            self.model = Qwen3Model(config)
+            # Monkey-patch the causal mask to avoid complex type operations
+            self.model._update_causal_mask = self._simple_causal_mask
+
+        def _simple_causal_mask(
+            self,
+            attention_mask,
+            input_tensor,
+            cache_position=None,
+            past_key_values=None,
+            output_attentions=False,
+        ):
+            """ONNX-compatible causal mask without complex type casts."""
+            dtype = input_tensor.dtype
+            device = input_tensor.device
+            batch_size, seq_len = input_tensor.shape[:2]
+
+            # Upper-triangular causal mask (future tokens masked with large negative).
+            # Use dtype-aware min value (not hardcoded FP16 min) so this works
+            # correctly for BF16 and FP32 as well.
+            mask_value = torch.finfo(dtype).min * 0.5
+            causal_mask = torch.triu(
+                torch.full((seq_len, seq_len), mask_value, device=device, dtype=dtype),
+                diagonal=1,
+            )
+            causal_mask = causal_mask.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, -1, -1)
+
+            # Apply padding mask from attention_mask [B, seq_len]
+            if attention_mask is not None and attention_mask.dim() == 2:
+                padding_mask = attention_mask[:, None, None, :].to(dtype)
+                padding_mask = (1.0 - padding_mask) * mask_value
+                causal_mask = causal_mask + padding_mask
+
+            return causal_mask
+
+        def forward(self, inputs_embeds, attention_mask):
+            outputs = self.model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+            )
+            return outputs.last_hidden_state
+
+    wrapper = LLMForExport(llm_config)
+
+    # Load weights from the existing truncated Qwen3Model
+    original_qwen3_model = language_model.model  # Qwen3Model inside Qwen3ForCausalLM
+    wrapper.model.load_state_dict(original_qwen3_model.state_dict())
+
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    wrapper = wrapper.to(dtype).eval().cuda()
+
+    # Create dummy inputs
+    hidden_size = llm_config.hidden_size
+    inputs_embeds = torch.randn(1, seq_len, hidden_size, dtype=dtype, device="cuda")
+    attention_mask = torch.ones(1, seq_len, dtype=torch.int64, device="cuda")
+
+    logger.info(f"  inputs_embeds: {inputs_embeds.shape} ({inputs_embeds.dtype})")
+    logger.info(f"  attention_mask: {attention_mask.shape} ({attention_mask.dtype})")
+
+    output_path = os.path.join(output_dir, "llm_bf16.onnx")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    logger.info(f"  Exporting to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (inputs_embeds, attention_mask),
+            output_path,
+            input_names=["inputs_embeds", "attention_mask"],
+            output_names=["embeddings"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+                "embeddings": {0: "batch_size", 1: "sequence_length"},
+            },
+        )
+
+    # Consolidate external data into a single file for TRT compatibility.
+    # torch.onnx.export scatters weights as many small files; TRT parser
+    # needs them consolidated next to the .onnx file.
+    logger.info("  Consolidating external data...")
+    import onnx
+    from onnx.external_data_helper import convert_model_to_external_data
+
+    model = onnx.load(output_path)
+    external_data_file = os.path.basename(output_path) + ".data"
+    convert_model_to_external_data(
+        model,
+        all_tensors_to_one_file=True,
+        location=external_data_file,
+        size_threshold=0,
+    )
+    onnx.save(model, output_path)
+    logger.info(f"  External data consolidated to {external_data_file}")
+
+    # Clean up old scattered external data files
+    for f in os.listdir(output_dir):
+        fpath = os.path.join(output_dir, f)
+        if (
+            os.path.isfile(fpath)
+            and f.startswith("onnx__")
+            and f not in (os.path.basename(output_path), external_data_file)
+        ):
+            os.remove(fpath)
+
+    logger.info("  LLM exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# Export Functions: State Encoder
+# ============================================================
+
+
+def export_state_encoder_to_onnx(policy, output_dir, use_bf16=True):
+    """Export the state encoder (CategorySpecificMLP) to ONNX.
+
+    Input: state [B, 1, max_state_dim], embodiment_id [B]
+    Output: [B, 1, input_embedding_dim]
+    """
+    logger.info("\n" + "=" * 80)
+    logger.info("Exporting State Encoder to ONNX")
+    logger.info("=" * 80)
+
+    config = policy.model.action_head.config
+    state_encoder = policy.model.action_head.state_encoder
+
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    model = state_encoder.to(dtype).eval().cuda()
+
+    state = torch.randn(1, 1, config.max_state_dim, dtype=dtype, device="cuda")
+    embodiment_id = torch.zeros(1, dtype=torch.int64, device="cuda")
+
+    logger.info(f"  state: {state.shape} ({state.dtype})")
+    logger.info(f"  embodiment_id: {embodiment_id.shape} ({embodiment_id.dtype})")
+
+    output_path = os.path.join(output_dir, "state_encoder.onnx")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    logger.info(f"  Exporting to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            model,
+            (state, embodiment_id),
+            output_path,
+            input_names=["state", "embodiment_id"],
+            output_names=["output"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "state": {0: "batch_size"},
+                "embodiment_id": {0: "batch_size"},
+                "output": {0: "batch_size"},
+            },
+        )
+
+    logger.info("  State Encoder exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# Export Functions: Action Encoder
+# ============================================================
+
+
+def export_action_encoder_to_onnx(policy, output_dir, use_bf16=True):
+    """Export the action encoder (MultiEmbodimentActionEncoder) to ONNX.
+
+    Input: actions [B, action_horizon, max_action_dim], timesteps [B], embodiment_id [B]
+    Output: [B, action_horizon, input_embedding_dim]
+    """
+    logger.info("\n" + "=" * 80)
+    logger.info("Exporting Action Encoder to ONNX")
+    logger.info("=" * 80)
+
+    config = policy.model.action_head.config
+    action_encoder = policy.model.action_head.action_encoder
+
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    model = action_encoder.to(dtype).eval().cuda()
+
+    actions = torch.randn(
+        1, config.action_horizon, config.max_action_dim, dtype=dtype, device="cuda"
+    )
+    timesteps = torch.zeros(1, dtype=torch.int64, device="cuda")
+    embodiment_id = torch.zeros(1, dtype=torch.int64, device="cuda")
+
+    logger.info(f"  actions: {actions.shape} ({actions.dtype})")
+    logger.info(f"  timesteps: {timesteps.shape} ({timesteps.dtype})")
+    logger.info(f"  embodiment_id: {embodiment_id.shape} ({embodiment_id.dtype})")
+
+    output_path = os.path.join(output_dir, "action_encoder.onnx")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    logger.info(f"  Exporting to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            model,
+            (actions, timesteps, embodiment_id),
+            output_path,
+            input_names=["actions", "timesteps", "embodiment_id"],
+            output_names=["output"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "actions": {0: "batch_size"},
+                "timesteps": {0: "batch_size"},
+                "embodiment_id": {0: "batch_size"},
+                "output": {0: "batch_size"},
+            },
+        )
+
+    logger.info("  Action Encoder exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# Export Functions: DiT
+# ============================================================
 
 
 def export_dit_to_onnx(
     policy: Gr00tPolicy, captured_inputs: DiTInputCapture, output_path: str, use_bf16: bool = True
 ):
-    """
-    Export the DiT model to ONNX.
+    """Export the DiT (AlternateVLDiT) to ONNX.
 
-    Args:
-        policy: Loaded policy with model
-        captured_inputs: Captured input tensors from actual inference
-        output_path: Path to save ONNX model
-        use_bf16: Whether to export in FP16 precision
+    Input: sa_embs [B, sa_seq_len, input_embedding_dim],
+           vl_embs [B, vl_seq_len, backbone_embedding_dim],
+           timestep [B], image_mask [B, vl_seq_len],
+           backbone_attention_mask [B, vl_seq_len]
+    Output: [B, sa_seq_len, hidden_size]
     """
     logger.info("\n" + "=" * 80)
     logger.info("Exporting DiT to ONNX")
     logger.info("=" * 80)
 
-    # Extract DiT model
     dit_model = policy.model.action_head.model
     dit_model.eval()
 
-    # NOTE: Model is already in BF16 by default (from checkpoint)
-    # We only need to set the dtype for dummy inputs
-    if use_bf16:
-        # Use BF16 to match model's native precision and avoid accuracy loss
-        dtype = torch.bfloat16
-        logger.info("Using BF16 precision (native model precision)")
-    else:
-        dtype = torch.float32
-
-    dit_model = dit_model.cuda()
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    dit_model = dit_model.to(dtype).cuda()
 
     sa_embs = torch.randn(captured_inputs.sa_embs.shape, dtype=dtype, device="cuda")
     vl_embs = torch.randn(captured_inputs.vl_embs.shape, dtype=dtype, device="cuda")
@@ -175,11 +789,6 @@ def export_dit_to_onnx(
 
     export_inputs = [sa_embs, vl_embs, timestep]
     input_names = ["sa_embs", "vl_embs", "timestep"]
-    # Establish the dynamix_axes:
-    # For example:
-    #   vl_embs dimensions are [B, vl_seq_len, vl_embed]
-    #   The axes of B and vl_seq_len can vary i.e. batch sz and num tokens in input
-    #   vl_embed is fixed at 2048 and hence is not in dynalic)axes
     dynamic_axes = {
         "sa_embs": {0: "batch_size", 1: "sa_seq_len"},
         "vl_embs": {0: "batch_size", 1: "vl_seq_len"},
@@ -187,14 +796,12 @@ def export_dit_to_onnx(
         "output": {0: "batch_size", 1: "sa_seq_len"},
     }
 
-    image_mask = None
     if captured_inputs.image_mask is not None:
         image_mask = torch.ones(captured_inputs.image_mask.shape, dtype=torch.bool, device="cuda")
         export_inputs.append(image_mask)
         input_names.append("image_mask")
         dynamic_axes["image_mask"] = {0: "batch_size", 1: "vl_seq_len"}
 
-    backbone_attention_mask = None
     if captured_inputs.backbone_attention_mask is not None:
         backbone_attention_mask = torch.ones(
             captured_inputs.backbone_attention_mask.shape, dtype=torch.bool, device="cuda"
@@ -203,50 +810,38 @@ def export_dit_to_onnx(
         input_names.append("backbone_attention_mask")
         dynamic_axes["backbone_attention_mask"] = {0: "batch_size", 1: "vl_seq_len"}
 
-    logger.info("Export input shapes:")
-    logger.info(f"  sa_embs: {sa_embs.shape} ({sa_embs.dtype})")
-    logger.info(f"  vl_embs: {vl_embs.shape} ({vl_embs.dtype})")
-    logger.info(f"  timestep: {timestep.shape} ({timestep.dtype})")
-    if image_mask is not None:
-        logger.info(f"  image_mask: {image_mask.shape} ({image_mask.dtype})")
-    if backbone_attention_mask is not None:
-        logger.info(
-            f"  backbone_attention_mask: {backbone_attention_mask.shape} ({backbone_attention_mask.dtype})"
-        )
+    logger.info("  Export input shapes:")
+    for name, tensor in zip(input_names, export_inputs):
+        logger.info(f"    {name}: {tensor.shape} ({tensor.dtype})")
 
-    # Create output directory
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-    # Export to ONNX
-    logger.info(f"Exporting to {output_path}...")
-
-    # Create a wrapper to handle keyword arguments
-    # torch.onnx.export uses positional args: `dit.forward(arg1, arg2...)`
-    # DiT module uses keyword args: `dit.forward(hidden_states=....)`
-    # The DiTWrapper handles this translation
+    # Wrapper to convert positional args → keyword args for DiT
     class DiTWrapper(torch.nn.Module):
-        def __init__(self, dit_model, has_backbone_mask):
+        def __init__(self, dit_model, has_image_mask, has_backbone_mask):
             super().__init__()
             self.dit_model = dit_model
+            self.has_image_mask = has_image_mask
             self.has_backbone_mask = has_backbone_mask
 
-        def forward(self, sa_embs, vl_embs, timestep, image_mask, backbone_attention_mask=None):
-            # Call DiT with keyword arguments
-            if self.has_backbone_mask:
-                return self.dit_model(
-                    sa_embs,
-                    vl_embs,
-                    timestep,
-                    image_mask=image_mask,
-                    backbone_attention_mask=backbone_attention_mask,
-                )
-            else:
-                return self.dit_model(sa_embs, vl_embs, timestep, image_mask=image_mask)
+        def forward(
+            self, sa_embs, vl_embs, timestep, image_mask=None, backbone_attention_mask=None
+        ):
+            kwargs = {}
+            if self.has_image_mask and image_mask is not None:
+                kwargs["image_mask"] = image_mask
+            if self.has_backbone_mask and backbone_attention_mask is not None:
+                kwargs["backbone_attention_mask"] = backbone_attention_mask
+            return self.dit_model(sa_embs, vl_embs, timestep, **kwargs)
 
-    has_backbone_mask = backbone_attention_mask is not None
-    wrapped_model = DiTWrapper(dit_model, has_backbone_mask)
+    wrapped_model = DiTWrapper(
+        dit_model,
+        has_image_mask=captured_inputs.image_mask is not None,
+        has_backbone_mask=captured_inputs.backbone_attention_mask is not None,
+    )
     wrapped_model.eval()
 
+    logger.info(f"  Exporting to {output_path}...")
     with torch.inference_mode():
         torch.onnx.export(
             wrapped_model,
@@ -260,52 +855,584 @@ def export_dit_to_onnx(
             export_params=True,
         )
 
-    logger.info(" DiT exported successfully!")
+    logger.info("  DiT exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
 
-    # Verify the export
-    logger.info("\nVerifying ONNX export...")
-    import onnx
 
-    # Get file size first
-    file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
-    logger.info(f"Model size on disk: {file_size_mb:.2f} MB")
+# ============================================================
+# Export Functions: Action Decoder
+# ============================================================
 
-    # Check if external data file exists (for large models)
-    external_data_path = output_path.replace(".onnx", ".onnx.data")
-    if os.path.exists(external_data_path):
-        external_size_mb = os.path.getsize(external_data_path) / (1024 * 1024)
-        logger.info(f"External data size: {external_size_mb:.2f} MB")
-        logger.info(f"Total model size: {file_size_mb + external_size_mb:.2f} MB")
 
-    # For large models, validate using file path instead of loading into memory
-    try:
-        # Use model path checking for large models
-        onnx.checker.check_model(output_path)
-        logger.info(" ONNX model is valid!")
-    except ValueError as e:
-        if "too large" in str(e):
-            # Model is large, just verify it can be loaded
-            logger.info("Model is very large, skipping full validation...")
+def export_action_decoder_to_onnx(policy, output_dir, use_bf16=True):
+    """Export the action decoder (CategorySpecificMLP) to ONNX.
+
+    Input: model_output [B, sa_seq_len, hidden_size], embodiment_id [B]
+    Output: [B, sa_seq_len, max_action_dim]
+    """
+    logger.info("\n" + "=" * 80)
+    logger.info("Exporting Action Decoder to ONNX")
+    logger.info("=" * 80)
+
+    config = policy.model.action_head.config
+    action_decoder = policy.model.action_head.action_decoder
+
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+    model = action_decoder.to(dtype).eval().cuda()
+
+    # sa_seq_len = 1 (state) + action_horizon
+    sa_seq_len = 1 + config.action_horizon
+    model_output = torch.randn(1, sa_seq_len, config.hidden_size, dtype=dtype, device="cuda")
+    embodiment_id = torch.zeros(1, dtype=torch.int64, device="cuda")
+
+    logger.info(f"  model_output: {model_output.shape} ({model_output.dtype})")
+    logger.info(f"  embodiment_id: {embodiment_id.shape} ({embodiment_id.dtype})")
+
+    output_path = os.path.join(output_dir, "action_decoder.onnx")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    logger.info(f"  Exporting to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            model,
+            (model_output, embodiment_id),
+            output_path,
+            input_names=["model_output", "embodiment_id"],
+            output_names=["output"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "model_output": {0: "batch_size"},
+                "embodiment_id": {0: "batch_size"},
+                "output": {0: "batch_size"},
+            },
+        )
+
+    logger.info("  Action Decoder exported successfully!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# FP8 Quantization: Calibration Datasets & Quantize Functions
+# ============================================================
+
+
+def _load_calibration_observations(policy, dataset_path, video_backend, calib_size):
+    """Load a list of observations for calibration.
+
+    Returns observations WITHOUT batch dimension, matching the format expected
+    by VLAStepData (same as what _to_vla_step_data receives after unbatching).
+
+    Returns:
+        list of observation dicts with structure:
+            {"video": {key: ndarray(T, H, W, C)},
+             "state": {key: ndarray(T, D)},
+             "language": {key: [str]}}
+    """
+    modality_configs = policy.get_modality_config()
+    dataset = LeRobotEpisodeLoader(
+        dataset_path=dataset_path,
+        modality_configs=modality_configs,
+        video_backend=video_backend,
+    )
+
+    observations = []
+    for traj_idx in range(min(len(dataset), calib_size)):
+        try:
+            traj = dataset[traj_idx]
+            data_point = extract_step_data(
+                traj,
+                0,
+                modality_configs=modality_configs,
+                embodiment_tag=policy.embodiment_tag,
+            )
+            obs = {}
+            for key, value in data_point.states.items():
+                obs[f"state.{key}"] = value
+            for key, value in data_point.images.items():
+                obs[f"video.{key}"] = np.array(value)
+            for key in modality_configs["language"].modality_keys:
+                obs[key] = data_point.text
+            # parse_observation_gr00t adds a batch dim (arr[None,:]) needed for
+            # batched inference, but calibration datasets process single samples.
+            # Unbatch immediately so the data matches what VLAStepData expects
+            # (same format as _to_vla_step_data after _unbatch_observation).
+            parsed = parse_observation_gr00t(obs, modality_configs)
+            unbatched = {}
+            for modality in parsed:
+                unbatched[modality] = {}
+                for key, val in parsed[modality].items():
+                    if isinstance(val, list):
+                        unbatched[modality][key] = val[0]  # [[str]] -> [str]
+                    else:
+                        unbatched[modality][key] = val[0]  # (1,...) -> (...)
+            observations.append(unbatched)
+        except Exception as e:
+            logger.warning(f"  Skipping traj {traj_idx}: {e}")
+            continue
+        if len(observations) >= calib_size:
+            break
+
+    logger.info(f"  Loaded {len(observations)} calibration observations")
+    return observations
+
+
+class ViTCalibrationDataset(torch.utils.data.Dataset):
+    """Provides pixel_values tensors for ViT FP8 calibration."""
+
+    def __init__(self, policy, observations):
+        self.pixel_values_list = []
+        for obs in observations:
             try:
-                onnx.shape_inference.infer_shapes_path(output_path, output_path + ".tmp")
-                os.remove(output_path + ".tmp")
-                logger.info(" ONNX model structure verified!")
-            except Exception as e2:
-                logger.warning(f"Could not fully validate (this is OK): {e2}")
-                logger.info(" ONNX model exported (validation skipped for large model)")
-        else:
-            raise
+                with torch.inference_mode():
+                    from gr00t.data.types import MessageType, VLAStepData
+
+                    vla_step_data = VLAStepData(
+                        images=obs["video"],
+                        states=obs["state"],
+                        actions={},
+                        text=obs["language"][policy.language_key][0],
+                        embodiment=policy.embodiment_tag,
+                    )
+                    messages = [{"type": MessageType.EPISODE_STEP.value, "content": vla_step_data}]
+                    processed = policy.processor(messages)
+                    collated = policy.collate_fn([processed])
+                    pv = collated["inputs"]["pixel_values"]
+                    # pv is a list of tensors; for single-view, take first element
+                    if isinstance(pv, (list, tuple)):
+                        pv = torch.cat(pv, dim=0)
+                    self.pixel_values_list.append(pv.to(torch.bfloat16).cuda())
+            except Exception as e:
+                logger.warning(f"  Skipping calib sample: {e}")
+
+    def __len__(self):
+        return len(self.pixel_values_list)
+
+    def __getitem__(self, idx):
+        return self.pixel_values_list[idx]
+
+
+class LLMCalibrationDataset(torch.utils.data.Dataset):
+    """Provides (inputs_embeds, attention_mask) for LLM FP8 calibration.
+
+    Pre-computes ViT + pixel_shuffle + MLP1 + embedding scatter for each observation.
+    """
+
+    def __init__(self, policy, observations):
+        from gr00t.data.types import MessageType, VLAStepData
+
+        self.inputs_embeds_list = []
+        self.attention_mask_list = []
+
+        backbone = policy.model.backbone
+        eagle_model = backbone.model
+
+        for obs in observations:
+            try:
+                vla_step_data = VLAStepData(
+                    images=obs["video"],
+                    states=obs["state"],
+                    actions={},
+                    text=obs["language"][policy.language_key][0],
+                    embodiment=policy.embodiment_tag,
+                )
+                messages = [{"type": MessageType.EPISODE_STEP.value, "content": vla_step_data}]
+                processed = policy.processor(messages)
+                collated = policy.collate_fn([processed])
+                inputs = collated["inputs"]
+                inputs = {
+                    k: v.to(torch.bfloat16).cuda()
+                    if isinstance(v, torch.Tensor) and torch.is_floating_point(v)
+                    else (v.cuda() if isinstance(v, torch.Tensor) else v)
+                    for k, v in inputs.items()
+                }
+
+                with torch.inference_mode():
+                    backbone_inputs, _ = policy.model.prepare_input(inputs)
+                    pixel_values = backbone_inputs["pixel_values"]
+                    vit_embeds = eagle_model.extract_feature(pixel_values)
+
+                    input_ids = backbone_inputs["input_ids"]
+                    input_embeds = backbone.embedding_layer(input_ids)
+                    input_embeds = input_embeds.to(torch.bfloat16)
+                    vit_embeds = vit_embeds.to(torch.bfloat16)
+
+                    B, N, C = input_embeds.shape
+                    input_embeds = input_embeds.reshape(B * N, C)
+                    input_ids_flat = input_ids.reshape(B * N)
+                    selected = input_ids_flat == eagle_model.image_token_index
+                    input_embeds[selected] = vit_embeds.reshape(-1, C)[: selected.sum()]
+                    input_embeds = input_embeds.reshape(B, N, C)
+
+                    attention_mask = backbone_inputs["attention_mask"]
+                    if attention_mask.dtype != torch.int64:
+                        attention_mask = attention_mask.to(torch.int64)
+
+                self.inputs_embeds_list.append(input_embeds.cpu())
+                self.attention_mask_list.append(attention_mask.cpu())
+            except Exception as e:
+                logger.warning(f"  Skipping LLM calib sample: {e}")
+
+    def __len__(self):
+        return len(self.inputs_embeds_list)
+
+    def __getitem__(self, idx):
+        return {
+            "inputs_embeds": self.inputs_embeds_list[idx].cuda(),
+            "attention_mask": self.attention_mask_list[idx].cuda(),
+        }
+
+
+def quantize_and_export_vit_fp8(policy, observations, output_dir, image_size=252):
+    """FP8 quantize ViT and export to ONNX.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        observations: List of calibration observations
+        output_dir: Output directory for ONNX
+        image_size: Actual image resolution from inference capture
+    """
+    import modelopt.torch.quantization as mtq
+
+    logger.info("\n" + "=" * 80)
+    logger.info("FP8 Quantizing ViT (Siglip2)")
+    logger.info("=" * 80)
+
+    eagle_model = policy.model.backbone.model
+    original_vit = eagle_model.vision_model.vision_model
+
+    opt_model = (
+        Siglip2VisionTransformerOpt(original_vit, image_size=image_size)
+        .eval()
+        .cuda()
+        .to(torch.bfloat16)
+    )
+
+    # Create calibration dataset
+    calib_ds = ViTCalibrationDataset(policy, observations)
+    logger.info(f"  Calibration samples: {len(calib_ds)}")
+
+    # FP8 config: disable Conv2d quantization to preserve accuracy
+    quant_cfg = copy.deepcopy(mtq.FP8_DEFAULT_CFG)
+    quant_cfg["quant_cfg"]["nn.Conv2d"] = {"*": {"enable": False}}
+
+    def calibrate_loop(model):
+        with torch.inference_mode():
+            for i in range(min(len(calib_ds), 64)):
+                model(calib_ds[i])
+
+    mtq.quantize(opt_model, quant_cfg, forward_loop=calibrate_loop)
+
+    # Export quantized ONNX
+    pixel_values = torch.randn(1, 3, image_size, image_size, dtype=torch.bfloat16, device="cuda")
+    output_path = os.path.join(output_dir, "vit_bf16.onnx")
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info(f"  Exporting FP8-quantized ViT to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            opt_model,
+            (pixel_values,),
+            output_path,
+            input_names=["pixel_values"],
+            output_names=["vit_embeds"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "pixel_values": {0: "batch_size"},
+                "vit_embeds": {0: "batch_size"},
+            },
+        )
+
+    logger.info("  FP8-quantized ViT exported!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+def quantize_and_export_llm_fp8(policy, observations, seq_len, output_dir):
+    """FP8 quantize LLM and export to ONNX.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        observations: List of calibration observations
+        seq_len: LLM sequence length
+        output_dir: Output directory for ONNX
+    """
+    import modelopt.torch.quantization as mtq
+
+    logger.info("\n" + "=" * 80)
+    logger.info("FP8 Quantizing LLM (Qwen3)")
+    logger.info("=" * 80)
+
+    backbone = policy.model.backbone
+    language_model = backbone.model.language_model
+    select_layer = backbone.select_layer
+
+    # Save embedding layer for calibration dataset
+    if not hasattr(backbone, "embedding_layer"):
+        backbone.embedding_layer = language_model.get_input_embeddings()
+    if not hasattr(backbone, "image_token_index"):
+        backbone.image_token_index = backbone.model.image_token_index
+
+    llm_config = copy.deepcopy(language_model.config)
+    llm_config._attn_implementation = "eager"
+    llm_config.num_hidden_layers = select_layer
+
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3Model
+
+    # Create LLM wrapper (same as BF16 export)
+    class LLMForExport(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.model = Qwen3Model(config)
+            self.model._update_causal_mask = self._simple_causal_mask
+
+        def _simple_causal_mask(
+            self,
+            attention_mask,
+            input_tensor,
+            cache_position=None,
+            past_key_values=None,
+            output_attentions=False,
+        ):
+            dtype = input_tensor.dtype
+            device = input_tensor.device
+            batch_size, seq_len = input_tensor.shape[:2]
+            mask_value = torch.finfo(dtype).min * 0.5
+            causal_mask = torch.triu(
+                torch.full((seq_len, seq_len), mask_value, device=device, dtype=dtype),
+                diagonal=1,
+            )
+            causal_mask = causal_mask.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, -1, -1)
+            if attention_mask is not None and attention_mask.dim() == 2:
+                padding_mask = attention_mask[:, None, None, :].to(dtype)
+                padding_mask = (1.0 - padding_mask) * mask_value
+                causal_mask = causal_mask + padding_mask
+            return causal_mask
+
+        def forward(self, inputs_embeds, attention_mask):
+            outputs = self.model(inputs_embeds=inputs_embeds, attention_mask=attention_mask)
+            return outputs.last_hidden_state
+
+    wrapper = LLMForExport(llm_config)
+    original_qwen3_model = language_model.model
+    wrapper.model.load_state_dict(original_qwen3_model.state_dict())
+    wrapper = wrapper.to(torch.bfloat16).eval().cuda()
+
+    # Create calibration dataset
+    calib_ds = LLMCalibrationDataset(policy, observations)
+    logger.info(f"  LLM calibration samples: {len(calib_ds)}")
+
+    def calibrate_loop(model):
+        with torch.inference_mode():
+            for i in range(min(len(calib_ds), 64)):
+                sample = calib_ds[i]
+                model(sample["inputs_embeds"], sample["attention_mask"])
+
+    mtq.quantize(wrapper, mtq.FP8_DEFAULT_CFG, forward_loop=calibrate_loop)
+
+    # Export quantized ONNX
+    hidden_size = llm_config.hidden_size
+    inputs_embeds = torch.randn(1, seq_len, hidden_size, dtype=torch.bfloat16, device="cuda")
+    attention_mask = torch.ones(1, seq_len, dtype=torch.int64, device="cuda")
+    output_path = os.path.join(output_dir, "llm_bf16.onnx")
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info(f"  Exporting FP8-quantized LLM to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (inputs_embeds, attention_mask),
+            output_path,
+            input_names=["inputs_embeds", "attention_mask"],
+            output_names=["embeddings"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes={
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+                "embeddings": {0: "batch_size", 1: "sequence_length"},
+            },
+        )
+
+    # Consolidate external data
+    logger.info("  Consolidating external data...")
+    import onnx
+    from onnx.external_data_helper import convert_model_to_external_data
+
+    model_onnx = onnx.load(output_path)
+    external_data_file = os.path.basename(output_path) + ".data"
+    convert_model_to_external_data(
+        model_onnx,
+        all_tensors_to_one_file=True,
+        location=external_data_file,
+        size_threshold=0,
+    )
+    onnx.save(model_onnx, output_path)
+
+    # Clean up scattered files
+    for f in os.listdir(output_dir):
+        fpath = os.path.join(output_dir, f)
+        if (
+            os.path.isfile(fpath)
+            and f.startswith("onnx__")
+            and f not in (os.path.basename(output_path), external_data_file)
+        ):
+            os.remove(fpath)
+
+    logger.info("  FP8-quantized LLM exported!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+def quantize_and_export_dit_fp8(policy, captured_inputs, observations, output_dir):
+    """FP8 quantize DiT and export to ONNX.
+
+    Uses a multi-step denoising calibration loop to properly calibrate
+    the DiT's dynamic range across all denoising timesteps.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        captured_inputs: DiTInputCapture with captured tensor shapes
+        observations: List of calibration observations
+        output_dir: Output directory for ONNX
+    """
+    import modelopt.torch.quantization as mtq
+
+    logger.info("\n" + "=" * 80)
+    logger.info("FP8 Quantizing DiT")
+    logger.info("=" * 80)
+
+    dit_model = policy.model.action_head.model
+    dit_model.eval().to(torch.bfloat16).cuda()
+
+    # FP8 config with attention quantizer tuning
+    quant_cfg = copy.deepcopy(mtq.FP8_DEFAULT_CFG)
+    quant_cfg["quant_cfg"]["*[qkv]_bmm_quantizer"] = {"num_bits": (4, 3), "axis": None}
+    quant_cfg["quant_cfg"]["*softmax_quantizer"] = {"num_bits": (4, 3), "axis": None}
+
+    def dit_calibrate_loop(model):
+        """Run full denoising loop for DiT calibration.
+
+        policy.get_action() expects batched observations (B, T, ...).
+        Calibration observations are unbatched, so re-add batch dim here.
+        """
+        with torch.inference_mode():
+            for obs in observations[:32]:
+                try:
+                    batched_obs = {
+                        "video": {k: v[None, ...] for k, v in obs["video"].items()},
+                        "state": {k: v[None, ...] for k, v in obs["state"].items()},
+                        "language": {k: [v] for k, v in obs["language"].items()},
+                    }
+                    action, _ = policy.get_action(batched_obs)
+                except Exception:
+                    continue
+
+    mtq.quantize(dit_model, quant_cfg, forward_loop=dit_calibrate_loop)
+
+    # Export (same structure as BF16 export)
+    dtype = torch.bfloat16
+    sa_embs = torch.randn(captured_inputs.sa_embs.shape, dtype=dtype, device="cuda")
+    vl_embs = torch.randn(captured_inputs.vl_embs.shape, dtype=dtype, device="cuda")
+    timestep = torch.ones(captured_inputs.timestep.shape, dtype=torch.int64, device="cuda")
+
+    export_inputs = [sa_embs, vl_embs, timestep]
+    input_names = ["sa_embs", "vl_embs", "timestep"]
+    dynamic_axes = {
+        "sa_embs": {0: "batch_size", 1: "sa_seq_len"},
+        "vl_embs": {0: "batch_size", 1: "vl_seq_len"},
+        "timestep": {0: "batch_size"},
+        "output": {0: "batch_size", 1: "sa_seq_len"},
+    }
+
+    if captured_inputs.image_mask is not None:
+        image_mask = torch.ones(captured_inputs.image_mask.shape, dtype=torch.bool, device="cuda")
+        export_inputs.append(image_mask)
+        input_names.append("image_mask")
+        dynamic_axes["image_mask"] = {0: "batch_size", 1: "vl_seq_len"}
+
+    if captured_inputs.backbone_attention_mask is not None:
+        bb_mask = torch.ones(
+            captured_inputs.backbone_attention_mask.shape, dtype=torch.bool, device="cuda"
+        )
+        export_inputs.append(bb_mask)
+        input_names.append("backbone_attention_mask")
+        dynamic_axes["backbone_attention_mask"] = {0: "batch_size", 1: "vl_seq_len"}
+
+    class DiTWrapper(torch.nn.Module):
+        def __init__(self, dit_model, has_image_mask, has_backbone_mask):
+            super().__init__()
+            self.dit_model = dit_model
+            self.has_image_mask = has_image_mask
+            self.has_backbone_mask = has_backbone_mask
+
+        def forward(
+            self, sa_embs, vl_embs, timestep, image_mask=None, backbone_attention_mask=None
+        ):
+            kwargs = {}
+            if self.has_image_mask and image_mask is not None:
+                kwargs["image_mask"] = image_mask
+            if self.has_backbone_mask and backbone_attention_mask is not None:
+                kwargs["backbone_attention_mask"] = backbone_attention_mask
+            return self.dit_model(sa_embs, vl_embs, timestep, **kwargs)
+
+    wrapped = DiTWrapper(
+        dit_model,
+        has_image_mask=captured_inputs.image_mask is not None,
+        has_backbone_mask=captured_inputs.backbone_attention_mask is not None,
+    ).eval()
+
+    output_path = os.path.join(output_dir, "dit_bf16.onnx")
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info(f"  Exporting FP8-quantized DiT to {output_path}...")
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapped,
+            tuple(export_inputs),
+            output_path,
+            input_names=input_names,
+            output_names=["output"],
+            opset_version=19,
+            do_constant_folding=True,
+            dynamic_axes=dynamic_axes,
+            export_params=True,
+        )
+
+    logger.info("  FP8-quantized DiT exported!")
+    verify_onnx_export(output_path)
+    return output_path
+
+
+# ============================================================
+# Main
+# ============================================================
 
 
 def main(args):
     logger.info("=" * 80)
-    logger.info("GrootN1d6 ONNX Export Script")
+    logger.info("GR00T N1.6 ONNX Export Script")
     logger.info("=" * 80)
-    logger.info(f"Model path: {args.model_path}")
-    logger.info(f"Dataset path: {args.dataset_path}")
-    logger.info(f"Embodiment: {args.embodiment_tag}")
-    logger.info(f"Output directory: {args.output_dir}")
+    logger.info(f"Model path:    {args.model_path}")
+    logger.info(f"Dataset path:  {args.dataset_path}")
+    logger.info(f"Embodiment:    {args.embodiment_tag}")
+    logger.info(f"Output dir:    {args.output_dir}")
+    logger.info(f"Export mode:   {args.export_mode}")
+    logger.info(f"Precision:     {args.precision}")
     logger.info("=" * 80)
+
+    use_fp8 = args.precision == "fp8"
+    if use_fp8:
+        try:
+            import modelopt.torch.quantization as mtq  # noqa: F401
+
+            logger.info("  nvidia-modelopt loaded successfully")
+        except ImportError:
+            logger.error("  FP8 requires nvidia-modelopt: uv pip install 'nvidia-modelopt[torch]'")
+            return
 
     # Step 1: Load the policy
     logger.info("\n[Step 1] Loading policy...")
@@ -314,7 +1441,7 @@ def main(args):
         model_path=args.model_path,
         device="cuda",
     )
-    logger.info(" Policy loaded")
+    logger.info("  Policy loaded")
 
     # Step 2: Load dataset
     logger.info("\n[Step 2] Loading dataset...")
@@ -324,36 +1451,174 @@ def main(args):
         video_backend=args.video_backend,
         video_backend_kwargs=None,
     )
-    logger.info(f" Dataset loaded ({len(dataset)} trajectories)")
+    logger.info(f"  Dataset loaded ({len(dataset)} trajectories)")
 
-    # Step 3: Capture DiT inputs
-    logger.info("\n[Step 3] Capturing DiT inputs from actual inference...")
+    # Step 3: Capture component inputs from actual inference
+    logger.info("\n[Step 3] Capturing component inputs from actual inference...")
 
-    # Set up hook to capture inputs
-    capture = DiTInputCapture()
+    dit_capture = DiTInputCapture()
     hook = policy.model.action_head.model.register_forward_pre_hook(
-        capture.hook_fn, with_kwargs=True
+        dit_capture.hook_fn, with_kwargs=True
     )
 
-    # Run one inference to capture shapes
+    # Also capture pixel_values shape to determine actual image resolution
+    # (Eagle's smart_resize may change 224→252 depending on input images)
+    captured_pixel_values_shape = [None]
+
+    def capture_pixel_values(module, args, kwargs):
+        if captured_pixel_values_shape[0] is None:
+            # pixel_values may be positional (args[0]) or keyword
+            pv = args[0] if len(args) > 0 else kwargs.get("pixel_values")
+            if pv is not None:
+                if isinstance(pv, (list, tuple)) and len(pv) > 0:
+                    captured_pixel_values_shape[0] = pv[0].shape
+                elif isinstance(pv, torch.Tensor):
+                    captured_pixel_values_shape[0] = pv.shape
+
+    eagle_model = policy.model.backbone.model
+    vit_hook = eagle_model.vision_model.vision_model.register_forward_pre_hook(
+        capture_pixel_values, with_kwargs=True
+    )
+
     observation = prepare_observation(policy, dataset, traj_idx=0)
-    logger.info("Running inference to capture shapes...")
+    logger.info("  Running inference to capture shapes...")
     with torch.inference_mode():
         _ = policy.get_action(observation)
 
-    # Remove hook
     hook.remove()
+    vit_hook.remove()
 
-    if not capture.captured:
-        logger.error(" Failed to capture DiT inputs!")
+    if not dit_capture.captured:
+        logger.error("  Failed to capture DiT inputs!")
         return
 
-    # Step 4: Export DiT
-    logger.info("\n[Step 4] Exporting DiT to ONNX...")
-    dit_output_path = os.path.join(args.output_dir, "dit_model.onnx")
-    export_dit_to_onnx(
-        policy=policy, captured_inputs=capture, output_path=dit_output_path, use_bf16=True
-    )
+    # Derive LLM seq_len from captured DiT inputs
+    # vl_embs shape is [B, vl_seq_len, backbone_embedding_dim]
+    # vl_seq_len == LLM output seq_len
+    llm_seq_len = dit_capture.vl_embs.shape[1]
+    logger.info(f"  Derived LLM sequence length: {llm_seq_len}")
+
+    # Derive actual image size from captured pixel_values
+    # pixel_values shape: (B, C, H, W) — H should equal W
+    if captured_pixel_values_shape[0] is not None:
+        captured_image_size = captured_pixel_values_shape[0][-1]  # W dimension
+        logger.info(f"  Captured image size: {captured_image_size}x{captured_image_size}")
+    else:
+        captured_image_size = 224
+        logger.warning("  Could not capture pixel_values shape, defaulting to 224")
+
+    # Save export metadata for downstream tools (builder, inference)
+    action_head_config = policy.model.action_head.config
+    sa_seq_len = 1 + action_head_config.action_horizon  # 1 state + action_horizon
+    vit_config = policy.model.backbone.model.vision_model.vision_model.config
+    export_metadata = {
+        "image_size": int(captured_image_size),
+        "patch_size": int(vit_config.patch_size),
+        "llm_seq_len": int(llm_seq_len),
+        "sa_seq_len": int(sa_seq_len),
+        "vl_seq_len": int(llm_seq_len),
+        "action_horizon": int(action_head_config.action_horizon),
+        "max_action_dim": int(action_head_config.max_action_dim),
+        "hidden_size": int(action_head_config.hidden_size),
+        "embodiment_tag": str(args.embodiment_tag),
+        "export_mode": args.export_mode,
+        "precision": args.precision,
+    }
+    os.makedirs(args.output_dir, exist_ok=True)
+    metadata_path = os.path.join(args.output_dir, "export_metadata.json")
+    with open(metadata_path, "w") as f:
+        json.dump(export_metadata, f, indent=2)
+    logger.info(f"  Saved export metadata to {metadata_path}")
+
+    # Step 4: Export components
+
+    if args.export_mode == "dit_only":
+        # Backward-compatible: export only DiT
+        logger.info("\n[Step 4] Exporting DiT to ONNX (dit_only mode)...")
+        dit_output_path = os.path.join(args.output_dir, "dit_model.onnx")
+        export_dit_to_onnx(
+            policy=policy,
+            captured_inputs=dit_capture,
+            output_path=dit_output_path,
+            use_bf16=True,
+        )
+
+    elif args.export_mode == "full_pipeline":
+        logger.info("\n[Step 4] Exporting full pipeline to ONNX...")
+
+        if use_fp8:
+            # FP8 mode: quantize + export components that benefit from FP8
+            calib_path = args.calib_dataset_path or args.dataset_path
+            logger.info(f"\n[Step 4 FP8] Loading calibration data from {calib_path}...")
+            calib_observations = _load_calibration_observations(
+                policy, calib_path, args.video_backend, args.calib_size
+            )
+
+            # 4a. FP8 ViT
+            logger.info("\n--- [4a] ViT (Siglip2) FP8 ---")
+            quantize_and_export_vit_fp8(
+                policy,
+                calib_observations,
+                args.output_dir,
+                image_size=captured_image_size,
+            )
+
+            # 4b. FP8 LLM
+            logger.info("\n--- [4b] LLM FP8 ---")
+            quantize_and_export_llm_fp8(policy, calib_observations, llm_seq_len, args.output_dir)
+
+            # 4c. State Encoder (small model, BF16 is fine)
+            logger.info("\n--- [4c] State Encoder (BF16) ---")
+            export_state_encoder_to_onnx(policy, args.output_dir, use_bf16=True)
+
+            # 4d. Action Encoder (small model, BF16 is fine)
+            logger.info("\n--- [4d] Action Encoder (BF16) ---")
+            export_action_encoder_to_onnx(policy, args.output_dir, use_bf16=True)
+
+            # 4e. FP8 DiT
+            logger.info("\n--- [4e] DiT FP8 ---")
+            quantize_and_export_dit_fp8(policy, dit_capture, calib_observations, args.output_dir)
+
+            # 4f. Action Decoder (small model, BF16 is fine)
+            logger.info("\n--- [4f] Action Decoder (BF16) ---")
+            export_action_decoder_to_onnx(policy, args.output_dir, use_bf16=True)
+
+        else:
+            # BF16 mode: standard export
+            # 4a. Export ViT (Siglip2)
+            logger.info("\n--- [4a] ViT (Siglip2) ---")
+            export_vit_to_onnx(
+                policy,
+                args.output_dir,
+                use_bf16=True,
+                captured_image_size=captured_image_size,
+            )
+
+            # 4b. Export LLM
+            logger.info("\n--- [4b] LLM ---")
+            export_llm_to_onnx(policy, llm_seq_len, args.output_dir, use_bf16=True)
+
+            # 4c. Export State Encoder
+            logger.info("\n--- [4c] State Encoder ---")
+            export_state_encoder_to_onnx(policy, args.output_dir, use_bf16=True)
+
+            # 4d. Export Action Encoder
+            logger.info("\n--- [4d] Action Encoder ---")
+            export_action_encoder_to_onnx(policy, args.output_dir, use_bf16=True)
+
+            # 4e. Export DiT
+            logger.info("\n--- [4e] DiT ---")
+            dit_output_path = os.path.join(args.output_dir, "dit_bf16.onnx")
+            export_dit_to_onnx(
+                policy=policy,
+                captured_inputs=dit_capture,
+                output_path=dit_output_path,
+                use_bf16=True,
+            )
+
+            # 4f. Export Action Decoder
+            logger.info("\n--- [4f] Action Decoder ---")
+            export_action_decoder_to_onnx(policy, args.output_dir, use_bf16=True)
 
     # Summary
     logger.info("\n" + "=" * 80)
@@ -361,9 +1626,16 @@ def main(args):
     logger.info("=" * 80)
     logger.info(f"\nExported files in: {args.output_dir}")
 
+    # List exported files
+    for f in sorted(os.listdir(args.output_dir)):
+        fpath = os.path.join(args.output_dir, f)
+        if os.path.isfile(fpath):
+            size_mb = os.path.getsize(fpath) / (1024 * 1024)
+            logger.info(f"  {f}: {size_mb:.2f} MB")
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Export GrootN1d6 model to ONNX")
+    parser = argparse.ArgumentParser(description="Export GR00T N1.6 model to ONNX")
     parser.add_argument(
         "--model_path", type=str, required=True, help="Path to the model checkpoint"
     )
@@ -386,10 +1658,37 @@ if __name__ == "__main__":
         help="Output directory for ONNX models",
     )
     parser.add_argument(
+        "--export_mode",
+        type=str,
+        default="dit_only",
+        choices=["dit_only", "full_pipeline"],
+        help="Export mode: 'dit_only' (default) or 'full_pipeline'",
+    )
+    parser.add_argument(
         "--video_backend",
         type=str,
         default="torchcodec",
         help="Options: ['decord', 'torchvision_av', 'torchcodec']",
+    )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp8"],
+        help="Export precision: 'bf16' (default) or 'fp8' (requires nvidia-modelopt)",
+    )
+    parser.add_argument(
+        "--calib_dataset_path",
+        type=str,
+        default=None,
+        help="Path to calibration dataset for FP8 quantization. "
+        "If not provided, uses --dataset_path.",
+    )
+    parser.add_argument(
+        "--calib_size",
+        type=int,
+        default=100,
+        help="Number of calibration samples for FP8 quantization (default: 100)",
     )
 
     args = parser.parse_args()

--- a/scripts/deployment/profile_vit_fp8_layers.py
+++ b/scripts/deployment/profile_vit_fp8_layers.py
@@ -20,17 +20,9 @@ Usage:
 """
 
 import argparse
+from collections import defaultdict
 import copy
 import logging
-from collections import defaultdict
-
-from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
-from gr00t.data.dataset.sharded_single_step_dataset import extract_step_data
-from gr00t.data.embodiment_tags import EmbodimentTag
-from gr00t.policy.gr00t_policy import Gr00tPolicy
-import numpy as np
-import torch
-import torch.nn.functional as F
 
 # Reuse ViT wrappers and calibration helpers from export_onnx_n1d6.py
 from export_onnx_n1d6 import (
@@ -39,6 +31,13 @@ from export_onnx_n1d6 import (
     _load_calibration_observations,
     parse_observation_gr00t,
 )
+from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
+from gr00t.data.dataset.sharded_single_step_dataset import extract_step_data
+from gr00t.data.embodiment_tags import EmbodimentTag
+from gr00t.policy.gr00t_policy import Gr00tPolicy
+import numpy as np
+import torch
+import torch.nn.functional as F
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -493,12 +492,8 @@ if __name__ == "__main__":
         description="ViT FP8 Per-Layer Cosine Profiling",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument(
-        "--model_path", type=str, required=True, help="Path to model checkpoint"
-    )
-    parser.add_argument(
-        "--dataset_path", type=str, required=True, help="Path to dataset"
-    )
+    parser.add_argument("--model_path", type=str, required=True, help="Path to model checkpoint")
+    parser.add_argument("--dataset_path", type=str, required=True, help="Path to dataset")
     parser.add_argument(
         "--embodiment_tag",
         type=EmbodimentTag,

--- a/scripts/deployment/profile_vit_fp8_layers.py
+++ b/scripts/deployment/profile_vit_fp8_layers.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""
+ViT FP8 Per-Layer Cosine Profiling for GR00T N1.6.
+
+Compares BF16 vs FP8-quantized Siglip2VisionTransformerOpt at each of the 27
+transformer layers to identify which layers contribute most to FP8 drift.
+
+This enables **partial quantization** — keeping high-drift layers in BF16
+while quantizing the rest, recovering accuracy with minimal speed loss.
+
+Both models use the SDPA attention path (no ONNX export), so the comparison
+isolates purely the FP8 quantization drift per layer.
+
+Usage:
+    uv run python scripts/deployment/profile_vit_fp8_layers.py \
+        --model_path nvidia/GR00T-N1.6-3B \
+        --dataset_path demo_data/gr1.PickNPlace \
+        --num_samples 16 \
+        --test_partial_quant
+"""
+
+import argparse
+import copy
+import logging
+from collections import defaultdict
+
+from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
+from gr00t.data.dataset.sharded_single_step_dataset import extract_step_data
+from gr00t.data.embodiment_tags import EmbodimentTag
+from gr00t.policy.gr00t_policy import Gr00tPolicy
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+# Reuse ViT wrappers and calibration helpers from export_onnx_n1d6.py
+from export_onnx_n1d6 import (
+    Siglip2VisionTransformerOpt,
+    ViTCalibrationDataset,
+    _load_calibration_observations,
+    parse_observation_gr00t,
+)
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ============================================================
+# Hook-based Layer Output Capture
+# ============================================================
+
+
+class LayerOutputCapture:
+    """Registers forward hooks on encoder layers to capture their outputs."""
+
+    def __init__(self, model):
+        """
+        Args:
+            model: Siglip2VisionTransformerOpt instance
+        """
+        self.outputs = defaultdict(list)  # layer_idx -> list of tensors
+        self._hooks = []
+
+        for idx, layer in enumerate(model.encoder.layers):
+            hook = layer.register_forward_hook(self._make_hook(idx))
+            self._hooks.append(hook)
+
+    def _make_hook(self, layer_idx):
+        def hook_fn(module, input, output):
+            # output is a tensor (B, N, C) from Siglip2EncoderLayerOpt.forward
+            self.outputs[layer_idx].append(output.detach().clone())
+
+        return hook_fn
+
+    def clear(self):
+        """Clear captured outputs for next sample."""
+        self.outputs.clear()
+
+    def remove_hooks(self):
+        """Remove all registered hooks."""
+        for h in self._hooks:
+            h.remove()
+        self._hooks.clear()
+
+
+# ============================================================
+# Per-Layer Metrics Computation
+# ============================================================
+
+
+def compute_layer_metrics(ref_tensor, test_tensor):
+    """Compute accuracy metrics between two tensors.
+
+    Args:
+        ref_tensor: Reference (BF16) output tensor
+        test_tensor: Test (FP8) output tensor
+
+    Returns:
+        dict with cosine_sim, l1_mean, relative_error
+    """
+    ref_f = ref_tensor.float().cpu().flatten()
+    test_f = test_tensor.float().cpu().flatten()
+
+    cos_sim = F.cosine_similarity(ref_f.unsqueeze(0), test_f.unsqueeze(0)).item()
+
+    diff = (ref_f - test_f).abs()
+    l1_mean = diff.mean().item()
+
+    ref_norm = ref_f.norm(p=2).item()
+    diff_norm = (ref_f - test_f).norm(p=2).item()
+    rel_err = diff_norm / ref_norm if ref_norm > 1e-8 else 0.0
+
+    return {"cosine_sim": cos_sim, "l1_mean": l1_mean, "relative_error": rel_err}
+
+
+def compute_full_model_cosine(ref_output, test_output):
+    """Compute cosine similarity between full model outputs."""
+    ref_f = ref_output.float().cpu().flatten()
+    test_f = test_output.float().cpu().flatten()
+    return F.cosine_similarity(ref_f.unsqueeze(0), test_f.unsqueeze(0)).item()
+
+
+# ============================================================
+# FP8 Quantization with Optional Layer Exclusion
+# ============================================================
+
+
+def quantize_vit_fp8(model, calib_ds, skip_layers=None):
+    """Apply FP8 quantization to a Siglip2VisionTransformerOpt model.
+
+    Args:
+        model: Siglip2VisionTransformerOpt instance (will be modified in-place)
+        calib_ds: ViTCalibrationDataset
+        skip_layers: Optional list of layer indices to exclude from FP8.
+                     These layers keep BF16 precision.
+
+    Returns:
+        The quantized model (same object, modified in-place)
+    """
+    import modelopt.torch.quantization as mtq
+
+    quant_cfg = copy.deepcopy(mtq.FP8_DEFAULT_CFG)
+    # Disable Conv2d quantization (patch embedding) — same as production config
+    quant_cfg["quant_cfg"]["nn.Conv2d"] = {"*": {"enable": False}}
+
+    # Disable quantization for specific encoder layers
+    if skip_layers:
+        for layer_idx in skip_layers:
+            # Disable all quantizers in this layer's subtree
+            layer_prefix = f"encoder.layers.{layer_idx}"
+            quant_cfg["quant_cfg"][f"*{layer_prefix}*"] = {"*": {"enable": False}}
+        logger.info(f"  Excluding layers {skip_layers} from FP8 quantization")
+
+    def calibrate_loop(model):
+        with torch.inference_mode():
+            for i in range(min(len(calib_ds), 64)):
+                model(calib_ds[i])
+
+    mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
+    return model
+
+
+# ============================================================
+# Profiling Orchestration
+# ============================================================
+
+
+def capture_image_size(policy, dataset):
+    """Run one inference to capture the actual image size after Eagle's smart_resize."""
+    captured_shape = [None]
+
+    def hook_fn(module, args, kwargs):
+        if captured_shape[0] is None:
+            pv = args[0] if len(args) > 0 else kwargs.get("pixel_values")
+            if pv is not None:
+                if isinstance(pv, (list, tuple)) and len(pv) > 0:
+                    captured_shape[0] = pv[0].shape
+                elif isinstance(pv, torch.Tensor):
+                    captured_shape[0] = pv.shape
+
+    eagle_model = policy.model.backbone.model
+    hook = eagle_model.vision_model.vision_model.register_forward_pre_hook(
+        hook_fn, with_kwargs=True
+    )
+
+    modality_configs = policy.get_modality_config()
+    traj = dataset[0]
+    data_point = extract_step_data(
+        traj, 0, modality_configs=modality_configs, embodiment_tag=policy.embodiment_tag
+    )
+    observation = {}
+    for key, value in data_point.states.items():
+        observation[f"state.{key}"] = value
+    for key, value in data_point.images.items():
+        observation[f"video.{key}"] = np.array(value)
+    for key in modality_configs["language"].modality_keys:
+        observation[key] = data_point.text
+    parsed_obs = parse_observation_gr00t(observation, modality_configs)
+
+    with torch.inference_mode():
+        _ = policy.get_action(parsed_obs)
+
+    hook.remove()
+
+    if captured_shape[0] is not None:
+        image_size = captured_shape[0][-1]
+        logger.info(f"  Captured image size: {image_size}x{image_size}")
+        return image_size
+    else:
+        logger.warning("  Could not capture image size, defaulting to 252")
+        return 252
+
+
+def run_profiling(policy, dataset, observations, image_size, num_samples, cosine_threshold):
+    """Run per-layer FP8 profiling and print results.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        dataset: Dataset loader (not used directly, image_size already captured)
+        observations: Calibration observations for FP8 quantization
+        image_size: Actual image resolution
+        num_samples: Number of samples to average over
+        cosine_threshold: Threshold below which a layer is marked as high-drift
+
+    Returns:
+        List of high-drift layer indices
+    """
+    eagle_model = policy.model.backbone.model
+    original_vit = eagle_model.vision_model.vision_model
+
+    # 1. Create BF16 baseline model
+    logger.info("\n[Step 1] Creating BF16 baseline model...")
+    model_bf16 = (
+        Siglip2VisionTransformerOpt(original_vit, image_size=image_size)
+        .eval()
+        .cuda()
+        .to(torch.bfloat16)
+    )
+    num_layers = len(model_bf16.encoder.layers)
+    logger.info(f"  {num_layers} encoder layers")
+
+    # 2. Create FP8 quantized model (deep copy weights first)
+    logger.info("\n[Step 2] Creating FP8 quantized model...")
+    model_fp8 = copy.deepcopy(model_bf16)
+
+    calib_ds = ViTCalibrationDataset(policy, observations)
+    logger.info(f"  Calibration samples: {len(calib_ds)}")
+
+    model_fp8 = quantize_vit_fp8(model_fp8, calib_ds)
+    logger.info("  FP8 quantization complete")
+
+    # 3. Register hooks on both models
+    logger.info("\n[Step 3] Registering forward hooks...")
+    capture_bf16 = LayerOutputCapture(model_bf16)
+    capture_fp8 = LayerOutputCapture(model_fp8)
+
+    # 4. Run samples through both models and accumulate metrics
+    logger.info(f"\n[Step 4] Running {num_samples} samples through both models...")
+    actual_samples = min(num_samples, len(calib_ds))
+
+    # Accumulate per-layer metrics
+    layer_metrics_accum = defaultdict(
+        lambda: {"cosine_sim": [], "l1_mean": [], "relative_error": []}
+    )
+    full_model_cosines = []
+
+    for i in range(actual_samples):
+        pixel_values = calib_ds[i]  # (1, 3, H, W) on CUDA, BF16
+
+        with torch.inference_mode():
+            out_bf16 = model_bf16(pixel_values)
+            out_fp8 = model_fp8(pixel_values)
+
+        # Full model cosine
+        full_model_cosines.append(compute_full_model_cosine(out_bf16, out_fp8))
+
+        # Per-layer metrics
+        for layer_idx in range(num_layers):
+            bf16_out = capture_bf16.outputs[layer_idx][-1]  # last captured for this sample
+            fp8_out = capture_fp8.outputs[layer_idx][-1]
+            metrics = compute_layer_metrics(bf16_out, fp8_out)
+            for k, v in metrics.items():
+                layer_metrics_accum[layer_idx][k].append(v)
+
+        capture_bf16.clear()
+        capture_fp8.clear()
+
+        if (i + 1) % 4 == 0:
+            logger.info(f"  Processed {i + 1}/{actual_samples} samples")
+
+    # Clean up hooks
+    capture_bf16.remove_hooks()
+    capture_fp8.remove_hooks()
+
+    # 5. Compute averaged metrics
+    logger.info("\n[Step 5] Computing averaged metrics...")
+    layer_results = []
+    for layer_idx in range(num_layers):
+        avg_metrics = {}
+        for k in ["cosine_sim", "l1_mean", "relative_error"]:
+            values = layer_metrics_accum[layer_idx][k]
+            avg_metrics[k] = sum(values) / len(values)
+        layer_results.append(avg_metrics)
+
+    avg_full_cosine = sum(full_model_cosines) / len(full_model_cosines)
+
+    # 6. Print report
+    print(f"\n{'=' * 72}")
+    print(f" ViT FP8 Per-Layer Cosine Profiling ({num_layers} layers, {actual_samples} samples)")
+    print(f"{'=' * 72}")
+    print(f"\n Full model cosine (BF16 vs FP8, SDPA path): {avg_full_cosine:.6f}")
+    print()
+    print(f" {'Layer':>5} | {'Cosine Sim':>10} | {'L1 Mean':>10} | {'Rel Error':>10} | {'Status'}")
+    print(f" {'-----':>5}-+-{'-' * 10}-+-{'-' * 10}-+-{'-' * 10}-+--------")
+
+    high_drift_layers = []
+    for layer_idx, metrics in enumerate(layer_results):
+        cos = metrics["cosine_sim"]
+        l1 = metrics["l1_mean"]
+        rel = metrics["relative_error"]
+
+        if cos < cosine_threshold:
+            status = "FAIL"
+            high_drift_layers.append(layer_idx)
+        elif cos < 0.995:
+            status = "WARN"
+        else:
+            status = "PASS"
+
+        marker = " <-- high drift" if status == "FAIL" else ""
+        print(f" {layer_idx:>5} | {cos:>10.6f} | {l1:>10.6f} | {rel:>10.6f} | {status}{marker}")
+
+    print()
+    if high_drift_layers:
+        print(f" High-drift layers (cosine < {cosine_threshold}): {high_drift_layers}")
+    else:
+        print(f" No high-drift layers found (all cosine >= {cosine_threshold})")
+
+    print(f"{'=' * 72}")
+
+    # Clean up models to free GPU memory
+    del model_bf16, model_fp8
+    torch.cuda.empty_cache()
+
+    return high_drift_layers
+
+
+def run_partial_quant_test(policy, observations, image_size, num_samples, skip_layers):
+    """Test partial quantization by excluding high-drift layers from FP8.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        observations: Calibration observations
+        image_size: Actual image resolution
+        num_samples: Number of samples to average over
+        skip_layers: Layer indices to exclude from FP8
+    """
+    eagle_model = policy.model.backbone.model
+    original_vit = eagle_model.vision_model.vision_model
+
+    # BF16 baseline
+    model_bf16 = (
+        Siglip2VisionTransformerOpt(original_vit, image_size=image_size)
+        .eval()
+        .cuda()
+        .to(torch.bfloat16)
+    )
+
+    calib_ds = ViTCalibrationDataset(policy, observations)
+
+    # Full FP8 model
+    logger.info("  Creating full FP8 model...")
+    model_full_fp8 = copy.deepcopy(model_bf16)
+    model_full_fp8 = quantize_vit_fp8(model_full_fp8, calib_ds)
+
+    # Partial FP8 model (skip high-drift layers)
+    logger.info(f"  Creating partial FP8 model (excluding layers {skip_layers})...")
+    model_partial_fp8 = copy.deepcopy(model_bf16)
+    model_partial_fp8 = quantize_vit_fp8(model_partial_fp8, calib_ds, skip_layers=skip_layers)
+
+    # Compare both against BF16
+    actual_samples = min(num_samples, len(calib_ds))
+    full_cosines = []
+    partial_cosines = []
+
+    for i in range(actual_samples):
+        pixel_values = calib_ds[i]
+        with torch.inference_mode():
+            out_bf16 = model_bf16(pixel_values)
+            out_full = model_full_fp8(pixel_values)
+            out_partial = model_partial_fp8(pixel_values)
+
+        full_cosines.append(compute_full_model_cosine(out_bf16, out_full))
+        partial_cosines.append(compute_full_model_cosine(out_bf16, out_partial))
+
+    avg_full = sum(full_cosines) / len(full_cosines)
+    avg_partial = sum(partial_cosines) / len(partial_cosines)
+    improvement = avg_partial - avg_full
+
+    print(f"\n{'=' * 72}")
+    print(" Partial Quantization Test")
+    print(f"{'=' * 72}")
+    print(f" Excluding layers {skip_layers} from FP8...")
+    print(f" Full FP8 model cosine:    {avg_full:.6f}")
+    print(f" Partial FP8 model cosine: {avg_partial:.6f}  ({improvement:+.4f})")
+
+    if avg_partial >= 0.995:
+        print(" Result: PASS (>= 0.995 threshold)")
+    elif avg_partial >= 0.990:
+        print(" Result: WARN (>= 0.990 but < 0.995)")
+    else:
+        print(" Result: FAIL (< 0.990, may need to exclude more layers)")
+
+    print(f"{'=' * 72}")
+
+    # Clean up
+    del model_bf16, model_full_fp8, model_partial_fp8
+    torch.cuda.empty_cache()
+
+
+# ============================================================
+# Main
+# ============================================================
+
+
+def main(args):
+    logger.info("=" * 72)
+    logger.info("ViT FP8 Per-Layer Cosine Profiling")
+    logger.info("=" * 72)
+    logger.info(f"Model path:   {args.model_path}")
+    logger.info(f"Dataset path: {args.dataset_path}")
+    logger.info(f"Embodiment:   {args.embodiment_tag}")
+    logger.info(f"Num samples:  {args.num_samples}")
+    logger.info(f"Threshold:    {args.cosine_threshold}")
+    logger.info(f"Test partial: {args.test_partial_quant}")
+
+    # Step 1: Load policy
+    logger.info("\nLoading policy...")
+    policy = Gr00tPolicy(
+        embodiment_tag=args.embodiment_tag,
+        model_path=args.model_path,
+        device="cuda",
+    )
+
+    # Step 2: Load dataset
+    logger.info("Loading dataset...")
+    dataset = LeRobotEpisodeLoader(
+        dataset_path=args.dataset_path,
+        modality_configs=policy.get_modality_config(),
+        video_backend=args.video_backend,
+    )
+    logger.info(f"  Dataset loaded ({len(dataset)} trajectories)")
+
+    # Step 3: Capture actual image size
+    logger.info("Capturing actual image size...")
+    image_size = capture_image_size(policy, dataset)
+
+    # Step 4: Load calibration observations
+    logger.info("Loading calibration observations...")
+    calib_path = args.calib_dataset_path or args.dataset_path
+    observations = _load_calibration_observations(
+        policy, calib_path, args.video_backend, args.calib_size
+    )
+
+    # Step 5: Run per-layer profiling
+    high_drift_layers = run_profiling(
+        policy=policy,
+        dataset=dataset,
+        observations=observations,
+        image_size=image_size,
+        num_samples=args.num_samples,
+        cosine_threshold=args.cosine_threshold,
+    )
+
+    # Step 6: Optional partial quantization test
+    if args.test_partial_quant and high_drift_layers:
+        logger.info("\nRunning partial quantization test...")
+        run_partial_quant_test(
+            policy=policy,
+            observations=observations,
+            image_size=image_size,
+            num_samples=args.num_samples,
+            skip_layers=high_drift_layers,
+        )
+    elif args.test_partial_quant and not high_drift_layers:
+        logger.info("\nSkipping partial quantization test — no high-drift layers found")
+
+    logger.info("\nDone!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="ViT FP8 Per-Layer Cosine Profiling",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model_path", type=str, required=True, help="Path to model checkpoint"
+    )
+    parser.add_argument(
+        "--dataset_path", type=str, required=True, help="Path to dataset"
+    )
+    parser.add_argument(
+        "--embodiment_tag",
+        type=EmbodimentTag,
+        default=EmbodimentTag.GR1,
+        help="Embodiment tag",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=16,
+        help="Number of samples to average over",
+    )
+    parser.add_argument(
+        "--cosine_threshold",
+        type=float,
+        default=0.990,
+        help="Cosine threshold below which a layer is marked high-drift",
+    )
+    parser.add_argument(
+        "--test_partial_quant",
+        action="store_true",
+        help="Test partial quantization by excluding high-drift layers",
+    )
+    parser.add_argument(
+        "--video_backend",
+        type=str,
+        default="torchcodec",
+        help="Video decoding backend",
+    )
+    parser.add_argument(
+        "--calib_dataset_path",
+        type=str,
+        default=None,
+        help="Calibration dataset path (defaults to --dataset_path)",
+    )
+    parser.add_argument(
+        "--calib_size",
+        type=int,
+        default=100,
+        help="Max calibration observations to load",
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/scripts/deployment/run_trt_pipeline.sh
+++ b/scripts/deployment/run_trt_pipeline.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# =============================================================================
+# GR00T N1.6 TensorRT Full Pipeline: Export, Build, Validate, Benchmark
+#
+# Usage:
+#   bash scripts/deployment/run_trt_pipeline.sh [STEP] [OPTIONS]
+#
+# Steps (run one at a time, or "all" for the full sequence):
+#   export_bf16         - Export all 6 components to ONNX (BF16)
+#   build_bf16          - Build TRT engines from ONNX (BF16)
+#   compare             - Accuracy validation: TRT vs PyTorch (quick 3-level)
+#   compare_detailed    - Per-component accuracy isolation (8 tests)
+#   benchmark           - Performance benchmark (Eager / TRT)
+#   export_fp8          - Export with FP8 quantization (requires nvidia-modelopt)
+#   build_fp8           - Build TRT engines from ONNX (FP8)
+#   compare_fp8         - Accuracy validation for FP8 engines
+#   compare_detailed_fp8 - Per-component accuracy isolation for FP8 engines
+#   benchmark_fp8       - Performance benchmark for FP8 engines
+#   profile_vit         - ViT FP8 per-layer cosine profiling (identify high-drift layers)
+#   all                 - Run export_bf16 → build_bf16 → compare → benchmark
+#
+# Examples:
+#   bash scripts/deployment/run_trt_pipeline.sh export_bf16
+#   bash scripts/deployment/run_trt_pipeline.sh compare
+#   bash scripts/deployment/run_trt_pipeline.sh profile_vit
+#   bash scripts/deployment/run_trt_pipeline.sh all
+#   MODEL=./my_model DATASET=./my_data bash scripts/deployment/run_trt_pipeline.sh all
+#
+# Acceptance Criteria (source: scripts/deployment/accuracy_thresholds.py):
+#
+#   BF16:
+#     Backbone   cosine >= 0.999, L1 <= 0.01
+#     Action     cosine >= 0.99,  L1 <= 0.05
+#     E2E action cosine >= 0.99
+#     Component  PASS >= 0.999, WARN >= 0.99, else FAIL
+#
+#   FP8 (relaxed):
+#     Backbone   cosine >= 0.99,  L1 <= 0.05
+#     Action     cosine >= 0.98,  L1 <= 0.1
+#     E2E action cosine >= 0.98
+#     Component  PASS >= 0.99,  WARN >= 0.98, else FAIL
+#
+# Quick validation:
+#   bash scripts/deployment/run_trt_pipeline.sh compare           # BF16
+#   bash scripts/deployment/run_trt_pipeline.sh compare_fp8       # FP8
+#   bash scripts/deployment/run_trt_pipeline.sh compare_detailed  # per-component
+# =============================================================================
+set -euo pipefail
+
+# ── Configurable paths (override via environment variables) ──────────────────
+MODEL="${MODEL:-nvidia/GR00T-N1.6-3B}"
+DATASET="${DATASET:-demo_data/gr1.PickNPlace}"
+EMBODIMENT="${EMBODIMENT:-gr1}"
+ONNX_DIR="${ONNX_DIR:-./groot_n1d6_onnx}"
+ENGINE_DIR="${ENGINE_DIR:-./groot_n1d6_engines}"
+ONNX_DIR_FP8="${ONNX_DIR_FP8:-./groot_n1d6_onnx_fp8}"
+ENGINE_DIR_FP8="${ENGINE_DIR_FP8:-./groot_n1d6_engines_fp8}"
+CALIB_DATASET="${CALIB_DATASET:-${DATASET}}"
+CALIB_SIZE="${CALIB_SIZE:-100}"
+NUM_ITER="${NUM_ITER:-20}"
+PRECISION="${PRECISION:-bf16}"
+PROFILE_SAMPLES="${PROFILE_SAMPLES:-16}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Helper ───────────────────────────────────────────────────────────────────
+banner() {
+    echo ""
+    echo "========================================================================"
+    echo "  $1"
+    echo "========================================================================"
+    echo ""
+}
+
+# ── Step functions ───────────────────────────────────────────────────────────
+
+step_export_bf16() {
+    banner "Step 1/4: Export ONNX (BF16) — ViT + LLM + StateEnc + ActionEnc + DiT + ActionDec"
+    uv run python "${SCRIPT_DIR}/export_onnx_n1d6.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --output_dir "${ONNX_DIR}" \
+        --export_mode full_pipeline \
+        --precision bf16
+}
+
+step_build_bf16() {
+    banner "Step 2/4: Build TRT Engines (BF16)"
+    uv run python "${SCRIPT_DIR}/build_tensorrt_engine.py" \
+        --mode full_pipeline \
+        --onnx_dir "${ONNX_DIR}" \
+        --engine_dir "${ENGINE_DIR}" \
+        --precision bf16
+}
+
+step_compare() {
+    banner "Step 3/4: Accuracy Validation — PyTorch vs TRT"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR}" \
+        --trt_mode full_pipeline \
+        --compare
+}
+
+step_benchmark() {
+    banner "Step 4/4: Performance Benchmark"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR}" \
+        --trt_mode full_pipeline \
+        --skip_compile \
+        --num_iterations "${NUM_ITER}"
+}
+
+step_compare_detailed() {
+    banner "Detailed Accuracy: Per-component PyTorch vs TRT"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR}" \
+        --trt_mode full_pipeline \
+        --compare-detailed
+}
+
+step_export_fp8() {
+    banner "FP8: Export ONNX (FP8 quantized)"
+    echo "Requires: uv pip install 'nvidia-modelopt[torch]'"
+    uv run python "${SCRIPT_DIR}/export_onnx_n1d6.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --output_dir "${ONNX_DIR_FP8}" \
+        --export_mode full_pipeline \
+        --precision fp8 \
+        --calib_dataset_path "${CALIB_DATASET}" \
+        --calib_size "${CALIB_SIZE}"
+}
+
+step_build_fp8() {
+    banner "FP8: Build TRT Engines"
+    uv run python "${SCRIPT_DIR}/build_tensorrt_engine.py" \
+        --mode full_pipeline \
+        --onnx_dir "${ONNX_DIR_FP8}" \
+        --engine_dir "${ENGINE_DIR_FP8}" \
+        --precision fp8
+}
+
+step_compare_fp8() {
+    banner "FP8: Accuracy Validation — PyTorch vs TRT (FP8)"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR_FP8}" \
+        --trt_mode full_pipeline \
+        --compare
+}
+
+step_compare_detailed_fp8() {
+    banner "FP8: Detailed Accuracy — Per-component PyTorch vs TRT (FP8)"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR_FP8}" \
+        --trt_mode full_pipeline \
+        --compare-detailed
+}
+
+step_benchmark_fp8() {
+    banner "FP8: Performance Benchmark"
+    uv run python "${SCRIPT_DIR}/benchmark_inference.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --trt_engine_path "${ENGINE_DIR_FP8}" \
+        --trt_mode full_pipeline \
+        --skip_compile \
+        --num_iterations "${NUM_ITER}"
+}
+
+step_profile_vit() {
+    banner "FP8: ViT Per-Layer Cosine Profiling"
+    echo "Requires: uv pip install 'nvidia-modelopt[torch]'"
+    uv run python "${SCRIPT_DIR}/profile_vit_fp8_layers.py" \
+        --model_path "${MODEL}" \
+        --dataset_path "${DATASET}" \
+        --embodiment_tag "${EMBODIMENT}" \
+        --num_samples "${PROFILE_SAMPLES}" \
+        --calib_dataset_path "${CALIB_DATASET}" \
+        --calib_size "${CALIB_SIZE}" \
+        --test_partial_quant
+}
+
+step_all() {
+    step_export_bf16
+    step_build_bf16
+    step_compare
+    step_benchmark
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+STEP="${1:-}"
+
+if [ -z "${STEP}" ]; then
+    echo "Usage: bash $0 <step>"
+    echo ""
+    echo "BF16 steps: export_bf16 | build_bf16 | compare | compare_detailed | benchmark"
+    echo "FP8 steps:  export_fp8 | build_fp8 | compare_fp8 | compare_detailed_fp8 | benchmark_fp8"
+    echo "Profiling:  profile_vit"
+    echo "Full:       all"
+    echo ""
+    echo "Environment variables (override defaults):"
+    echo "  MODEL          = ${MODEL}"
+    echo "  DATASET        = ${DATASET}"
+    echo "  EMBODIMENT     = ${EMBODIMENT}"
+    echo "  ONNX_DIR       = ${ONNX_DIR}       (BF16 ONNX)"
+    echo "  ENGINE_DIR     = ${ENGINE_DIR}     (BF16 engines)"
+    echo "  ONNX_DIR_FP8   = ${ONNX_DIR_FP8}   (FP8 ONNX)"
+    echo "  ENGINE_DIR_FP8 = ${ENGINE_DIR_FP8} (FP8 engines)"
+    echo "  NUM_ITER         = ${NUM_ITER}"
+    echo "  PROFILE_SAMPLES  = ${PROFILE_SAMPLES}"
+    exit 1
+fi
+
+case "${STEP}" in
+    export_bf16)  step_export_bf16 ;;
+    build_bf16)   step_build_bf16 ;;
+    compare)           step_compare ;;
+    compare_detailed)  step_compare_detailed ;;
+    benchmark)         step_benchmark ;;
+    export_fp8)             step_export_fp8 ;;
+    build_fp8)              step_build_fp8 ;;
+    compare_fp8)            step_compare_fp8 ;;
+    compare_detailed_fp8)   step_compare_detailed_fp8 ;;
+    benchmark_fp8)          step_benchmark_fp8 ;;
+    profile_vit)            step_profile_vit ;;
+    all)                    step_all ;;
+    *)
+        echo "ERROR: Unknown step '${STEP}'"
+        echo "Valid BF16 steps: export_bf16 | build_bf16 | compare | compare_detailed | benchmark"
+        echo "Valid FP8 steps:  export_fp8 | build_fp8 | compare_fp8 | compare_detailed_fp8 | benchmark_fp8"
+        echo "Profiling: profile_vit"
+        echo "Full: all"
+        exit 1
+        ;;
+esac
+
+banner "Done: ${STEP}"

--- a/scripts/deployment/trt_model_forward.py
+++ b/scripts/deployment/trt_model_forward.py
@@ -1,0 +1,473 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorRT forward functions for GR00T N1.6 full-pipeline inference.
+
+This module provides TRT-accelerated forward functions that replace the
+PyTorch backbone and action head during inference. Adapted from N1.5
+deployment_scripts/trt_model_forward.py for the N1.6 architecture.
+
+Architecture (full_pipeline mode):
+  Backbone: ViT (TRT) → pixel_shuffle_back (PyTorch) → MLP1 (PyTorch)
+            → embed + scatter (PyTorch) → LLM (TRT)
+  Action Head: VLLN (PyTorch) → State Encoder (TRT) → denoising loop:
+               [ Action Encoder (TRT) → DiT (TRT) → Action Decoder (TRT) ]
+
+Note: ViT TRT is optional — if vit_bf16.engine is not found, falls back to
+PyTorch ViT.
+"""
+
+from functools import partial
+import logging
+import os
+import sys
+
+import torch
+from transformers.feature_extraction_utils import BatchFeature
+
+
+logger = logging.getLogger(__name__)
+
+
+# Ensure sibling modules are importable (scripts/deployment is not a package)
+_deploy_dir = os.path.dirname(os.path.abspath(__file__))
+if _deploy_dir not in sys.path:
+    sys.path.insert(0, _deploy_dir)
+from trt_torch import Engine  # noqa: E402
+
+
+# ============================================================
+# Backbone TRT Forward
+# ============================================================
+
+
+def eagle3_tensorrt_forward(self, vl_input):
+    """Replace EagleBackbone.forward() with TRT-accelerated ViT + LLM.
+
+    When a ViT TRT engine is available, it replaces the PyTorch ViT.
+    pixel_shuffle_back and MLP1 remain in PyTorch (small ops).
+    The LLM is always replaced with a TRT engine.
+
+    Args:
+        self: EagleBackbone instance (monkey-patched)
+        vl_input: BatchFeature with keys: input_ids, attention_mask, pixel_values
+    """
+    self.set_frozen_modules_to_eval_mode()
+
+    eagle_model = self.model  # Eagle3_VLForConditionalGeneration
+
+    # Extract only the keys we need
+    keys_to_use = ["input_ids", "attention_mask", "pixel_values"]
+    vl_input = {k: vl_input[k] for k in keys_to_use}
+
+    pixel_values = vl_input["pixel_values"]
+    engine_dtype = torch.bfloat16
+
+    if hasattr(self, "vit_engine") and self.vit_engine is not None:
+        # --- ViT TRT Engine ---
+        # pixel_values is a list of tensors from the processor; stack into single tensor
+        if isinstance(pixel_values, (list, tuple)):
+            pv = torch.cat(pixel_values, dim=0)  # (B, 3, H, H)
+        else:
+            pv = pixel_values
+        if pv.dtype != engine_dtype:
+            pv = pv.to(engine_dtype)
+
+        self.vit_engine.set_runtime_tensor_shape("pixel_values", pv.shape)
+        vit_embeds = self.vit_engine(pv)["vit_embeds"]  # (B, num_patches, 1152)
+
+        # pixel_shuffle_back + MLP1 (stay in PyTorch — small ops)
+        # Derive patches_per_side from pixel_values shape and saved patch_size
+        patches_per_side = pv.shape[-1] // self.patch_size  # e.g. 252/14=18
+        spatial_shapes = torch.tensor(
+            [[patches_per_side, patches_per_side]] * vit_embeds.shape[0],
+            device=vit_embeds.device,
+            dtype=torch.int32,
+        )
+        vit_embeds, spatial_shapes = self._pixel_shuffle_back(vit_embeds, spatial_shapes)
+        vit_embeds = self._mlp1(vit_embeds)
+        B, N, C = vit_embeds.shape
+        vit_embeds = vit_embeds.reshape(B * N, C)
+    else:
+        # --- ViT + pixel_shuffle_back + MLP1 (all PyTorch) ---
+        vit_embeds = eagle_model.extract_feature(pixel_values)
+    # vit_embeds: [B*N, C] (flattened across batch and spatial dims)
+
+    # --- Create input embeddings and scatter vision tokens ---
+    input_ids = vl_input["input_ids"]
+    input_embeds = self.embedding_layer(input_ids)
+
+    # Ensure consistent dtype for TRT engine
+    engine_dtype = torch.bfloat16
+    if input_embeds.dtype != engine_dtype:
+        input_embeds = input_embeds.to(engine_dtype)
+    if vit_embeds.dtype != engine_dtype:
+        vit_embeds = vit_embeds.to(engine_dtype)
+
+    B, N, C = input_embeds.shape
+    input_embeds = input_embeds.reshape(B * N, C)
+
+    input_ids_flat = input_ids.reshape(B * N)
+    selected = input_ids_flat == self.image_token_index
+    n_image_tokens = selected.sum().item()
+    vit_embeds_flat = vit_embeds.reshape(-1, C)
+    n_vit_tokens = vit_embeds_flat.shape[0]
+
+    if n_image_tokens != n_vit_tokens:
+        logger.warning(
+            f"Vision token count mismatch: {n_image_tokens} image_token slots "
+            f"vs {n_vit_tokens} ViT output tokens. Truncating to min."
+        )
+        n_fill = min(n_image_tokens, n_vit_tokens)
+        input_embeds[selected] = input_embeds[selected] * 0.0
+        input_embeds[selected][:n_fill] = vit_embeds_flat[:n_fill]
+    else:
+        input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds_flat
+
+    input_embeds = input_embeds.reshape(B, N, C)
+
+    # --- LLM TRT Engine ---
+    attention_mask = vl_input["attention_mask"]
+    if attention_mask.dtype != torch.int64:
+        attention_mask = attention_mask.to(torch.int64)
+
+    self.llm_engine.set_runtime_tensor_shape("inputs_embeds", input_embeds.shape)
+    self.llm_engine.set_runtime_tensor_shape("attention_mask", attention_mask.shape)
+    embeddings = self.llm_engine(input_embeds, attention_mask)["embeddings"]
+
+    # Build output (same as original EagleBackbone.forward)
+    image_mask = input_ids == self.image_token_index
+    backbone_attention_mask = attention_mask == 1
+
+    return BatchFeature(
+        data={
+            "backbone_features": embeddings,
+            "backbone_attention_mask": backbone_attention_mask,
+            "image_mask": image_mask,
+        }
+    )
+
+
+# ============================================================
+# Action Head TRT Forward
+# ============================================================
+
+
+def action_head_tensorrt_forward(self, backbone_output, action_input):
+    """Replace Gr00tN1d6ActionHead.get_action() with TRT-accelerated inference.
+
+    VLLN (LayerNorm) stays in PyTorch. State Encoder, Action Encoder,
+    DiT, and Action Decoder are replaced with TRT engines.
+
+    Args:
+        self: Gr00tN1d6ActionHead instance (monkey-patched)
+        backbone_output: BatchFeature with backbone_features, backbone_attention_mask, image_mask
+        action_input: BatchFeature with state, embodiment_id
+    """
+    # --- VLLN: LayerNorm in PyTorch (too small for TRT) ---
+    backbone_features = backbone_output.backbone_features
+    backbone_features = self.vlln(backbone_features)
+    vl_embs = backbone_features
+
+    embodiment_id = action_input.embodiment_id
+    batch_size = vl_embs.shape[0]
+    device = vl_embs.device
+
+    engine_dtype = torch.bfloat16
+
+    # Ensure consistent dtypes
+    if vl_embs.dtype != engine_dtype:
+        vl_embs = vl_embs.to(engine_dtype)
+    if action_input.state.dtype != engine_dtype:
+        action_input.state = action_input.state.to(engine_dtype)
+    if embodiment_id.dtype != torch.int64:
+        embodiment_id = embodiment_id.to(torch.int64)
+
+    # --- State Encoder TRT ---
+    self.state_encoder_engine.set_runtime_tensor_shape("state", action_input.state.shape)
+    self.state_encoder_engine.set_runtime_tensor_shape("embodiment_id", embodiment_id.shape)
+    state_features = self.state_encoder_engine(action_input.state, embodiment_id)["output"]
+
+    # --- Initialize actions as random noise ---
+    if hasattr(self, "init_actions"):
+        actions = self.init_actions.expand((batch_size, -1, -1))
+    else:
+        actions = torch.randn(
+            size=(batch_size, self.config.action_horizon, self.action_dim),
+            dtype=engine_dtype,
+            device=device,
+        )
+
+    num_steps = self.num_inference_timesteps
+    dt = 1.0 / num_steps
+
+    # --- Denoising loop ---
+    for t in range(num_steps):
+        t_cont = t / float(num_steps)
+        t_discretized = int(t_cont * self.num_timestep_buckets)
+
+        timesteps_tensor = torch.full(
+            size=(batch_size,), fill_value=t_discretized, device=device, dtype=torch.int64
+        )
+
+        # Action Encoder TRT
+        self.action_encoder_engine.set_runtime_tensor_shape("actions", actions.shape)
+        self.action_encoder_engine.set_runtime_tensor_shape("timesteps", timesteps_tensor.shape)
+        self.action_encoder_engine.set_runtime_tensor_shape("embodiment_id", embodiment_id.shape)
+        action_features = self.action_encoder_engine(
+            actions.to(engine_dtype), timesteps_tensor, embodiment_id
+        )["output"]
+
+        # Maybe add position embedding (stays in PyTorch)
+        if self.config.add_pos_embed:
+            pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+            pos_embs = self.position_embedding(pos_ids).unsqueeze(0).to(engine_dtype)
+            action_features = action_features + pos_embs
+
+        # Concatenate state + action embeddings
+        sa_embs = torch.cat((state_features, action_features), dim=1).to(engine_dtype)
+
+        # DiT TRT
+        self.dit_engine.set_runtime_tensor_shape("sa_embs", sa_embs.shape)
+        self.dit_engine.set_runtime_tensor_shape("vl_embs", vl_embs.shape)
+        self.dit_engine.set_runtime_tensor_shape("timestep", timesteps_tensor.shape)
+
+        dit_kwargs = {}
+        if hasattr(backbone_output, "image_mask") and backbone_output.image_mask is not None:
+            image_mask = backbone_output.image_mask
+            self.dit_engine.set_runtime_tensor_shape("image_mask", image_mask.shape)
+            dit_kwargs["image_mask"] = image_mask
+
+        if (
+            hasattr(backbone_output, "backbone_attention_mask")
+            and backbone_output.backbone_attention_mask is not None
+        ):
+            bb_mask = backbone_output.backbone_attention_mask
+            self.dit_engine.set_runtime_tensor_shape("backbone_attention_mask", bb_mask.shape)
+            dit_kwargs["backbone_attention_mask"] = bb_mask
+
+        model_output = self.dit_engine(sa_embs, vl_embs, timesteps_tensor, **dit_kwargs)["output"]
+
+        # Action Decoder TRT
+        self.action_decoder_engine.set_runtime_tensor_shape("model_output", model_output.shape)
+        self.action_decoder_engine.set_runtime_tensor_shape("embodiment_id", embodiment_id.shape)
+        pred = self.action_decoder_engine(model_output, embodiment_id)["output"]
+        pred_velocity = pred[:, -self.action_horizon :]
+
+        # Euler integration
+        actions = actions + dt * pred_velocity
+
+    return BatchFeature(data={"action_pred": actions})
+
+
+# ============================================================
+# Engine Setup
+# ============================================================
+
+
+def setup_tensorrt_engines(policy, trt_engine_path, mode="full_pipeline"):
+    """Load TRT engines, delete PyTorch modules, and monkey-patch forward methods.
+
+    Args:
+        policy: Gr00tPolicy instance
+        trt_engine_path: Path to directory containing TRT engine files
+        mode: 'full_pipeline' or 'dit_only'
+    """
+    if mode == "full_pipeline":
+        _setup_full_pipeline(policy, trt_engine_path)
+    elif mode == "dit_only":
+        _setup_dit_only(policy, trt_engine_path)
+    else:
+        raise ValueError(f"Unknown mode: {mode}. Expected 'full_pipeline' or 'dit_only'.")
+
+
+def _setup_full_pipeline(policy, trt_engine_path):
+    """Set up all TRT engines for full-pipeline acceleration."""
+    backbone = policy.model.backbone
+    eagle_model = backbone.model  # Eagle3_VLForConditionalGeneration
+    action_head = policy.model.action_head
+
+    # --- Backbone setup ---
+    # Save embedding layer and image token index before deleting the language model
+    backbone.embedding_layer = eagle_model.language_model.get_input_embeddings()
+    backbone.image_token_index = eagle_model.image_token_index
+
+    # Check if ViT TRT engine is available
+    vit_engine_path = os.path.join(trt_engine_path, "vit_bf16.engine")
+
+    # Save pixel_shuffle_back, mlp1, and patch_size before potentially deleting vision_model
+    backbone._pixel_shuffle_back = eagle_model.pixel_shuffle_back
+    backbone._mlp1 = eagle_model.mlp1
+    backbone.patch_size = eagle_model.vision_model.vision_model.config.patch_size
+
+    if os.path.exists(vit_engine_path):
+        print(f"Loading ViT engine: {vit_engine_path}")
+        backbone.vit_engine = Engine(vit_engine_path)
+
+        del eagle_model.vision_model
+        torch.cuda.empty_cache()
+        print("  Deleted PyTorch ViT (replaced by TRT engine)")
+    else:
+        backbone.vit_engine = None
+        print(f"  ViT engine not found at {vit_engine_path}, using PyTorch ViT")
+
+    # Delete the language model to free GPU memory
+    del eagle_model.language_model
+    torch.cuda.empty_cache()
+
+    # Load LLM TRT engine
+    llm_engine_path = os.path.join(trt_engine_path, "llm_bf16.engine")
+    print(f"Loading LLM engine: {llm_engine_path}")
+    backbone.llm_engine = Engine(llm_engine_path)
+
+    # --- Action head setup ---
+    # Delete PyTorch modules that are replaced by TRT
+    if hasattr(action_head, "model"):
+        del action_head.model
+    if hasattr(action_head, "state_encoder"):
+        del action_head.state_encoder
+    if hasattr(action_head, "action_encoder"):
+        del action_head.action_encoder
+    if hasattr(action_head, "action_decoder"):
+        del action_head.action_decoder
+    torch.cuda.empty_cache()
+
+    # Verify action_dim consistency (export uses config.max_action_dim)
+    assert action_head.action_dim == action_head.config.max_action_dim, (
+        f"action_dim mismatch: action_head.action_dim={action_head.action_dim} "
+        f"!= config.max_action_dim={action_head.config.max_action_dim}"
+    )
+
+    # Load action head TRT engines
+    print(f"Loading action head engines from: {trt_engine_path}")
+    action_head.state_encoder_engine = Engine(os.path.join(trt_engine_path, "state_encoder.engine"))
+    action_head.action_encoder_engine = Engine(
+        os.path.join(trt_engine_path, "action_encoder.engine")
+    )
+    action_head.dit_engine = Engine(os.path.join(trt_engine_path, "dit_bf16.engine"))
+    action_head.action_decoder_engine = Engine(
+        os.path.join(trt_engine_path, "action_decoder.engine")
+    )
+
+    # Monkey-patch forward methods
+    backbone.forward = partial(eagle3_tensorrt_forward, backbone)
+    action_head.get_action = partial(action_head_tensorrt_forward, action_head)
+
+    print("Full-pipeline TRT engines loaded and forward methods patched.")
+
+
+def _setup_dit_only(policy, trt_engine_path):
+    """Set up TRT engine for DiT-only acceleration (backward compatible).
+
+    Only replaces the DiT model in the action head. The backbone and other
+    action head components remain in PyTorch.
+    """
+    action_head = policy.model.action_head
+
+    # Delete the PyTorch DiT model
+    if hasattr(action_head, "model"):
+        del action_head.model
+    torch.cuda.empty_cache()
+
+    # Load DiT TRT engine
+    # Support both naming conventions
+    dit_path = os.path.join(trt_engine_path, "dit_bf16.engine")
+    if not os.path.exists(dit_path):
+        dit_path = os.path.join(trt_engine_path, "dit_model_bf16.engine")
+    if not os.path.exists(dit_path):
+        # Try the old naming convention
+        dit_path = os.path.join(trt_engine_path, "dit_model_bf16.trt")
+
+    print(f"Loading DiT engine: {dit_path}")
+    action_head.dit_engine = Engine(dit_path)
+
+    # Monkey-patch only the get_action method
+    # We need a simpler forward that only replaces the DiT call
+    @torch.no_grad()
+    def dit_only_get_action_with_features(
+        backbone_features, state_features, embodiment_id, backbone_output
+    ):
+        """get_action_with_features with DiT replaced by TRT."""
+        vl_embs = backbone_features
+        batch_size = vl_embs.shape[0]
+        device = vl_embs.device
+        engine_dtype = torch.bfloat16
+
+        actions = torch.randn(
+            size=(batch_size, action_head.config.action_horizon, action_head.action_dim),
+            dtype=vl_embs.dtype,
+            device=device,
+        )
+
+        dt = 1.0 / action_head.num_inference_timesteps
+
+        for t in range(action_head.num_inference_timesteps):
+            t_cont = t / float(action_head.num_inference_timesteps)
+            t_discretized = int(t_cont * action_head.num_timestep_buckets)
+
+            timesteps_tensor = torch.full(
+                size=(batch_size,), fill_value=t_discretized, device=device
+            )
+            action_features = action_head.action_encoder(actions, timesteps_tensor, embodiment_id)
+
+            if action_head.config.add_pos_embed:
+                pos_ids = torch.arange(action_features.shape[1], dtype=torch.long, device=device)
+                pos_embs = action_head.position_embedding(pos_ids).unsqueeze(0)
+                action_features = action_features + pos_embs
+
+            sa_embs = torch.cat((state_features, action_features), dim=1).to(engine_dtype)
+
+            # Use TRT for DiT
+            vl_embs_trt = vl_embs.to(engine_dtype)
+            timesteps_trt = timesteps_tensor.to(torch.int64)
+
+            action_head.dit_engine.set_runtime_tensor_shape("sa_embs", sa_embs.shape)
+            action_head.dit_engine.set_runtime_tensor_shape("vl_embs", vl_embs_trt.shape)
+            action_head.dit_engine.set_runtime_tensor_shape("timestep", timesteps_trt.shape)
+
+            dit_kwargs = {}
+            if hasattr(backbone_output, "image_mask") and backbone_output.image_mask is not None:
+                image_mask = backbone_output.image_mask
+                action_head.dit_engine.set_runtime_tensor_shape("image_mask", image_mask.shape)
+                dit_kwargs["image_mask"] = image_mask
+
+            if (
+                hasattr(backbone_output, "backbone_attention_mask")
+                and backbone_output.backbone_attention_mask is not None
+            ):
+                bb_mask = backbone_output.backbone_attention_mask
+                action_head.dit_engine.set_runtime_tensor_shape(
+                    "backbone_attention_mask", bb_mask.shape
+                )
+                dit_kwargs["backbone_attention_mask"] = bb_mask
+
+            model_output = action_head.dit_engine(
+                sa_embs, vl_embs_trt, timesteps_trt, **dit_kwargs
+            )["output"]
+
+            pred = action_head.action_decoder(model_output, embodiment_id)
+            pred_velocity = pred[:, -action_head.action_horizon :]
+            actions = actions + dt * pred_velocity
+
+        return BatchFeature(
+            data={
+                "action_pred": actions,
+                "backbone_features": vl_embs,
+                "state_features": state_features,
+            }
+        )
+
+    action_head.get_action_with_features = dit_only_get_action_with_features
+    print("DiT-only TRT engine loaded and forward method patched.")

--- a/scripts/deployment/trt_torch.py
+++ b/scripts/deployment/trt_torch.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorRT Engine wrapper for GR00T N1.6 inference.
+
+Ported from N1.5 deployment_scripts/trt_torch.py with BF16 support added.
+"""
+
+import atexit
+import ctypes
+import os
+
+import tensorrt as trt
+import torch
+
+
+def torch_type(trt_type):
+    """Convert TensorRT data type to PyTorch equivalent."""
+    mapping = {
+        trt.float32: torch.float32,
+        trt.float16: torch.float16,
+        trt.bfloat16: torch.bfloat16,
+        trt.int8: torch.int8,
+        trt.int32: torch.int32,
+        trt.bool: torch.bool,
+        trt.uint8: torch.uint8,
+        trt.int64: torch.int64,
+    }
+    if trt_type in mapping:
+        return mapping[trt_type]
+
+    raise TypeError(
+        f"Could not resolve TensorRT datatype to an equivalent PyTorch datatype. {trt_type}"
+    )
+
+
+class Engine(object):
+    """TensorRT engine wrapper for loading and executing inference."""
+
+    def __init__(self, file, plugins=[]):
+        super().__init__()
+
+        self.logger = trt.Logger(trt.Logger.ERROR)
+        trt.init_libnvinfer_plugins(self.logger, "")
+
+        self.plugins = [ctypes.CDLL(plugin, ctypes.RTLD_GLOBAL) for plugin in plugins]
+        self.file = file
+        self.load(file)
+
+        def destroy(self):
+            del self.execution_context
+            del self.handle
+
+        atexit.register(destroy, self)
+        self.print()
+
+    def print(self):
+        """Display engine details (inputs/outputs) on rank 0 only."""
+        if int(os.getenv("LOCAL_RANK", -1)) not in [0, -1]:
+            return
+
+        print("============= TRT Engine Detail =============")
+        print(f"Engine file: {self.file}")
+        print(f"Inputs: {len(self.in_meta)}")
+        for ib, item in enumerate(self.in_meta):
+            tensor_name, shape, dtype = item[:3]
+            print(f"   {ib}. {tensor_name}: {'x'.join(map(str, shape))} [{dtype}]")
+
+        print(f"Outputs: {len(self.out_meta)}")
+        for ib, item in enumerate(self.out_meta):
+            tensor_name, shape, dtype = item[:3]
+            print(f"   {ib}. {tensor_name}: {'x'.join(map(str, shape))} [{dtype}]")
+        print("=============================================")
+
+    def load(self, file):
+        """Deserialize and load a TensorRT engine from file."""
+        runtime = trt.Runtime(self.logger)
+
+        with open(file, "rb") as f:
+            self.handle = runtime.deserialize_cuda_engine(f.read())
+            assert self.handle is not None, (
+                f"Failed to deserialize the cuda engine from file: {file}"
+            )
+
+        self.execution_context = self.handle.create_execution_context()
+        self.meta, self.in_meta, self.out_meta = [], [], []
+        for tensor_name in self.handle:
+            shape = self.handle.get_tensor_shape(tensor_name)
+            dtype = torch_type(self.handle.get_tensor_dtype(tensor_name))
+            if self.handle.get_tensor_mode(tensor_name) == trt.TensorIOMode.INPUT:
+                self.in_meta.append([tensor_name, shape, dtype])
+            else:
+                self.out_meta.append([tensor_name, shape, dtype])
+
+    def __call__(self, *args, **inputs):
+        return self.forward(*args, **inputs)
+
+    def set_runtime_tensor_shape(self, name, shape):
+        """Set runtime input shape for dynamic dimensions."""
+        self.execution_context.set_input_shape(name, shape)
+
+    def forward(self, *args, **kwargs):
+        """Execute TRT inference with the given input tensors.
+
+        Accepts both positional and keyword arguments.
+        Returns a dict of output tensors by default, or a list if return_list=True.
+        """
+        return_list = kwargs.pop("return_list", False)
+        reference_tensors = []
+        stream = torch.cuda.current_stream()
+
+        # Process positional arguments
+        for iarg, x in enumerate(args):
+            name, shape, dtype = self.in_meta[iarg]
+            runtime_shape = self.execution_context.get_tensor_shape(name)
+            assert isinstance(x, torch.Tensor), f"Unsupported tensor type: {type(x)}"
+            assert runtime_shape == x.shape, f"Invalid input shape: {runtime_shape} != {x.shape}"
+            assert dtype == x.dtype, (
+                f"Invalid tensor dtype, expected dtype is {dtype}, but got {x.dtype}"
+            )
+            assert x.is_cuda, f"Invalid tensor device, expected device is cuda, but got {x.device}"
+            x = x.cuda().contiguous()
+            self.execution_context.set_tensor_address(name, x.data_ptr())
+            reference_tensors.append(x)
+
+        # Process keyword arguments
+        for name, shape, dtype in self.in_meta:
+            if name not in kwargs:
+                continue
+
+            runtime_shape = self.execution_context.get_tensor_shape(name)
+            x = kwargs[name]
+            assert isinstance(x, torch.Tensor), f"Unsupported tensor[{name}] type: {type(x)}"
+            assert runtime_shape == x.shape, (
+                f"Invalid input[{name}] shape: {x.shape}, but the expected shape is: {runtime_shape}"
+            )
+            assert dtype == x.dtype, (
+                f"Invalid tensor[{name}] dtype, expected dtype is {dtype}, but got {x.dtype}"
+            )
+            assert x.is_cuda, (
+                f"Invalid tensor[{name}] device, expected device is cuda, but got {x.device}"
+            )
+            x = x.cuda().contiguous()
+            self.execution_context.set_tensor_address(name, x.data_ptr())
+            reference_tensors.append(x)
+
+        # Allocate output tensors
+        for item in self.out_meta:
+            name = item[0]
+            runtime_shape = self.execution_context.get_tensor_shape(name)
+            output_tensor = torch.zeros(
+                *runtime_shape, dtype=item[2], device=reference_tensors[0].device
+            )
+            self.execution_context.set_tensor_address(name, output_tensor.data_ptr())
+            reference_tensors.append(output_tensor)
+
+        # Execute
+        self.execution_context.execute_async_v3(stream.cuda_stream)
+        stream.synchronize()
+        assert len(reference_tensors) == len(self.in_meta) + len(self.out_meta), (
+            f"Invalid input tensors. The expected I/O tensors are "
+            f"{len(self.in_meta) + len(self.out_meta)}, but got {len(reference_tensors)}"
+        )
+
+        if return_list:
+            return [
+                reference_tensors[len(self.in_meta) + i] for i, item in enumerate(self.out_meta)
+            ]
+        else:
+            return {
+                item[0]: reference_tensors[len(self.in_meta) + i]
+                for i, item in enumerate(self.out_meta)
+            }

--- a/scripts/deployment/vit_trt_compile.py
+++ b/scripts/deployment/vit_trt_compile.py
@@ -26,6 +26,7 @@ import os
 import torch
 import torch.nn.functional as F
 
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -67,9 +68,8 @@ def compile_vit(policy, output_dir, image_size=None):
     Returns:
         Path to the compiled model file, or None on failure
     """
-    import torch_tensorrt
-
     from export_onnx_n1d6 import Siglip2VisionTransformerOpt
+    import torch_tensorrt
 
     eagle_model = policy.model.backbone.model
     original_vit = eagle_model.vision_model.vision_model
@@ -77,7 +77,6 @@ def compile_vit(policy, output_dir, image_size=None):
     # Auto-detect image size from a sample inference if not provided
     if image_size is None:
         from export_onnx_n1d6 import prepare_observation
-
         from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
 
         dataset = LeRobotEpisodeLoader(
@@ -162,9 +161,7 @@ def compile_vit(policy, output_dir, image_size=None):
         logger.info(f"Compiled vs Wrapper cosine: {cos_sim_wrapper:.6f}")
 
         if cos_sim_compiled < 0.999:
-            logger.warning(
-                f"Compiled ViT cosine {cos_sim_compiled:.6f} is below 0.999 threshold!"
-            )
+            logger.warning(f"Compiled ViT cosine {cos_sim_compiled:.6f} is below 0.999 threshold!")
 
         # Save compiled model
         os.makedirs(output_dir, exist_ok=True)

--- a/scripts/deployment/vit_trt_compile.py
+++ b/scripts/deployment/vit_trt_compile.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Compile Siglip2 ViT using torch_tensorrt with SDPA preserved.
+
+This script compiles the ViT wrapper using torch_tensorrt's dynamo backend,
+which can handle F.scaled_dot_product_attention natively — avoiding the
+flash→manual attention numerical drift seen in the ONNX export path.
+
+Prerequisites:
+    - TensorRT >= 10.8 (earlier versions have SDPA correctness bugs)
+    - torch_tensorrt: uv pip install torch_tensorrt
+
+Usage:
+    uv run python scripts/deployment/vit_trt_compile.py \
+        --model_path nvidia/GR00T-N1.6-3B \
+        --dataset_path demo_data/gr1.PickNPlace \
+        --output_dir ./groot_n1d6_engines
+
+The compiled ViT is saved as `vit_trt_compiled.ep` (ExportedProgram format).
+It can be loaded alongside ONNX-based TRT engines in the full pipeline.
+"""
+
+import argparse
+import logging
+import os
+
+import torch
+import torch.nn.functional as F
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def check_prerequisites():
+    """Check TRT and torch_tensorrt versions."""
+    import tensorrt as trt
+
+    trt_version = trt.__version__
+    trt_major_minor = tuple(int(x) for x in trt_version.split(".")[:2])
+    logger.info(f"TensorRT version: {trt_version}")
+
+    if trt_major_minor < (10, 8):
+        logger.error(
+            f"TensorRT {trt_version} has known SDPA correctness bugs. "
+            f"Requires >= 10.8. See https://github.com/NVIDIA/TensorRT/issues/4333"
+        )
+        return False
+
+    try:
+        import torch_tensorrt
+
+        logger.info(f"torch_tensorrt version: {torch_tensorrt.__version__}")
+    except ImportError:
+        logger.error("torch_tensorrt not installed. Run: uv pip install torch_tensorrt")
+        return False
+
+    return True
+
+
+def compile_vit(policy, output_dir, image_size=None):
+    """Compile the ViT using torch_tensorrt with SDPA preserved.
+
+    Args:
+        policy: Loaded Gr00tPolicy
+        output_dir: Directory to save compiled model
+        image_size: Override image size (auto-detected if None)
+
+    Returns:
+        Path to the compiled model file, or None on failure
+    """
+    import torch_tensorrt
+
+    from export_onnx_n1d6 import Siglip2VisionTransformerOpt
+
+    eagle_model = policy.model.backbone.model
+    original_vit = eagle_model.vision_model.vision_model
+
+    # Auto-detect image size from a sample inference if not provided
+    if image_size is None:
+        from export_onnx_n1d6 import prepare_observation
+
+        from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
+
+        dataset = LeRobotEpisodeLoader(
+            dataset_path=args.dataset_path,
+            modality_configs=policy.get_modality_config(),
+            video_backend="torchcodec",
+        )
+
+        captured_shape = [None]
+
+        def capture_hook(module, args, kwargs):
+            pv = args[0] if len(args) > 0 else kwargs.get("pixel_values")
+            if pv is not None and captured_shape[0] is None:
+                if isinstance(pv, (list, tuple)):
+                    captured_shape[0] = pv[0].shape
+                else:
+                    captured_shape[0] = pv.shape
+
+        hook = original_vit.register_forward_pre_hook(capture_hook, with_kwargs=True)
+        obs = prepare_observation(policy, dataset, traj_idx=0)
+        with torch.inference_mode():
+            policy.get_action(obs)
+        hook.remove()
+
+        if captured_shape[0] is not None:
+            image_size = captured_shape[0][-1]
+        else:
+            image_size = 252  # default for GR1
+        logger.info(f"Detected image size: {image_size}")
+
+    # Create SDPA-only wrapper (no manual matmul fallback needed for torch_tensorrt)
+    logger.info("Creating Siglip2VisionTransformerOpt wrapper...")
+    opt_vit = Siglip2VisionTransformerOpt(original_vit, image_size=image_size)
+    opt_vit = opt_vit.eval().cuda().to(torch.bfloat16)
+
+    # Verify wrapper accuracy vs original
+    dummy_input = torch.randn(1, 3, image_size, image_size, device="cuda", dtype=torch.bfloat16)
+    with torch.inference_mode():
+        orig_out = original_vit([dummy_input]).last_hidden_state
+        wrapper_out = opt_vit(dummy_input)
+
+    cos_sim = F.cosine_similarity(
+        orig_out.float().flatten().unsqueeze(0),
+        wrapper_out.float().flatten().unsqueeze(0),
+    ).item()
+    logger.info(f"Wrapper vs Original cosine: {cos_sim:.6f}")
+
+    # Compile with torch_tensorrt
+    logger.info("Compiling ViT with torch_tensorrt...")
+    logger.info("  This uses SDPA natively (no matmul+softmax decomposition)")
+
+    try:
+        # Use dynamo backend for best SDPA support.
+        # Use fixed batch_size=1 to avoid ConstraintViolationError from dynamo
+        # inferring batch dim as constant during tracing. Inference is always batch=1.
+        compiled_vit = torch_tensorrt.compile(
+            opt_vit,
+            ir="dynamo",
+            inputs=[
+                torch_tensorrt.Input(
+                    shape=[1, 3, image_size, image_size],
+                    dtype=torch.bfloat16,
+                )
+            ],
+            enabled_precisions={torch.bfloat16},
+            truncate_double=True,
+        )
+
+        # Verify compiled output
+        with torch.inference_mode():
+            compiled_out = compiled_vit(dummy_input)
+
+        cos_sim_compiled = F.cosine_similarity(
+            orig_out.float().flatten().unsqueeze(0),
+            compiled_out.float().flatten().unsqueeze(0),
+        ).item()
+        logger.info(f"Compiled vs Original cosine: {cos_sim_compiled:.6f}")
+        cos_sim_wrapper = F.cosine_similarity(
+            wrapper_out.float().flatten().unsqueeze(0),
+            compiled_out.float().flatten().unsqueeze(0),
+        ).item()
+        logger.info(f"Compiled vs Wrapper cosine: {cos_sim_wrapper:.6f}")
+
+        if cos_sim_compiled < 0.999:
+            logger.warning(
+                f"Compiled ViT cosine {cos_sim_compiled:.6f} is below 0.999 threshold!"
+            )
+
+        # Save compiled model
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, "vit_trt_compiled.ep")
+        torch_tensorrt.save(compiled_vit, output_path, output_format="exported_program")
+        logger.info(f"Saved compiled ViT to {output_path}")
+
+        file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
+        logger.info(f"File size: {file_size_mb:.2f} MB")
+
+        return output_path
+
+    except Exception as e:
+        logger.error(f"torch_tensorrt compilation failed: {e}")
+        logger.info("Falling back to ONNX export path for ViT.")
+        return None
+
+
+def main():
+    global args
+    parser = argparse.ArgumentParser(description="Compile ViT with torch_tensorrt")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="nvidia/GR00T-N1.6-3B",
+        help="Model checkpoint path",
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="demo_data/gr1.PickNPlace",
+        help="Dataset for shape capture",
+    )
+    parser.add_argument("--output_dir", type=str, default="./groot_n1d6_engines", help="Output dir")
+    parser.add_argument("--image_size", type=int, default=None, help="Override image size")
+    parser.add_argument(
+        "--check_only", action="store_true", help="Only check prerequisites, don't compile"
+    )
+
+    args = parser.parse_args()
+
+    if not check_prerequisites():
+        return
+
+    if args.check_only:
+        logger.info("Prerequisites check passed!")
+        return
+
+    from gr00t.data.embodiment_tags import EmbodimentTag
+    from gr00t.policy.gr00t_policy import Gr00tPolicy
+
+    logger.info("Loading policy...")
+    policy = Gr00tPolicy(
+        embodiment_tag=EmbodimentTag.GR1,
+        model_path=args.model_path,
+        device="cuda",
+    )
+
+    compile_vit(policy, args.output_dir, image_size=args.image_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -8,12 +8,6 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 
-[manifest]
-members = [
-    "gr00t",
-    "groot-infra",
-]
-
 [[package]]
 name = "accelerate"
 version = "1.12.0"
@@ -138,20 +132,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
 
 [[package]]
-name = "anyio"
-version = "4.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup" },
-    { name = "idna" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -191,34 +171,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/44/5e183bcb9333fc3372ee6e683be8b0c9b515a506894b2d32ff465430c074/av-16.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:05ad70933ac3b8ef896a820ea64b33b6cca91a5fac5259cb9ba7fa010435be15", size = 40123516, upload-time = "2026-01-09T20:18:09.955Z" },
     { url = "https://files.pythonhosted.org/packages/12/1d/b5346d582a3c3d958b4d26a2cc63ce607233582d956121eb20d2bbe55c2e/av-16.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d831a1062a3c47520bf99de6ec682bd1d64a40dfa958e5457bb613c5270e7ce3", size = 41463289, upload-time = "2026-01-09T20:18:12.459Z" },
     { url = "https://files.pythonhosted.org/packages/fa/31/acc946c0545f72b8d0d74584cb2a0ade9b7dfe2190af3ef9aa52a2e3c0b1/av-16.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:358ab910fef3c5a806c55176f2b27e5663b33c4d0a692dafeb049c6ed71f8aff", size = 31754959, upload-time = "2026-01-09T20:18:14.718Z" },
-]
-
-[[package]]
-name = "boto3"
-version = "1.42.48"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/f4/524155166b3f5c0a42822f70e85541a70da6e772618bf5e19df0f43f3a54/boto3-1.42.48.tar.gz", hash = "sha256:f4e37445be869157c4aaa53ef3e1b1d1986f9722e64d36f4894de832dd4b11ef", size = 112826, upload-time = "2026-02-12T20:34:56.176Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/2b/ed626f8d77895bfff397469c7408681e819dc5ddb07a3a20d731b09a8950/boto3-1.42.48-py3-none-any.whl", hash = "sha256:c9164fae0dc196f5040cf15d4fbc309475b09cb15649087fad4b65af55f815f2", size = 140605, upload-time = "2026-02-12T20:34:54.198Z" },
-]
-
-[[package]]
-name = "botocore"
-version = "1.42.48"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/15/9ff12462f2afbc57600c8708e502cb9b6f67f89bd59ba8a7c109f948beae/botocore-1.42.48.tar.gz", hash = "sha256:970983e520de6d85981379efd44dbf293dbc6288d376169787b3b23ea8cd6163", size = 14952450, upload-time = "2026-02-12T20:34:45.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/62/433536da54db704f8534a77498c6fd423004998a13e18c2b2ce720f9b19b/botocore-1.42.48-py3-none-any.whl", hash = "sha256:57d23635a90239051bab1e1e980401890ec2d87ded38623b1e4570260aec56f7", size = 14625740, upload-time = "2026-02-12T20:34:41.59Z" },
 ]
 
 [[package]]
@@ -669,18 +621,6 @@ wheels = [
 ]
 
 [[package]]
-name = "googleapis-common-protos"
-version = "1.72.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
-]
-
-[[package]]
 name = "gr00t"
 version = "0.1.0"
 source = { editable = "." }
@@ -779,40 +719,6 @@ requires-dist = [
 provides-extras = ["dev", "gpu"]
 
 [[package]]
-name = "groot-infra"
-version = "0.1.0"
-source = { editable = "groot_infra" }
-dependencies = [
-    { name = "boto3" },
-    { name = "httpx" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
-    { name = "pytest" },
-    { name = "ray" },
-    { name = "requests" },
-    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "tyro" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "boto3", specifier = ">=1.28.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
-    { name = "opentelemetry-api", specifier = ">=1.20.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
-    { name = "pytest", specifier = ">=7.0" },
-    { name = "ray", specifier = ">=2.0" },
-    { name = "requests", specifier = ">=2.28.0" },
-    { name = "torch", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'", specifier = ">=2.0" },
-    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "tyro", specifier = ">=0.5.0" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "gymnasium"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -825,15 +731,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/1c/d70b2ddd067992fa0332deae08293ef2dc489917ac5342e0e4b8850641f6/gymnasium-1.2.2.tar.gz", hash = "sha256:46d927328f8518bb5a689dbe270d228c1da2b08bcb71ae0152c10aa66f48d530", size = 829250, upload-time = "2025-11-04T15:21:06.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/53/39cd8c2f85e213fce1f32367c4bdbd3402d3bcde7d0826a1172a0f2c5cc0/gymnasium-1.2.2-py3-none-any.whl", hash = "sha256:f04ec362b1fdf73a8b327db5ef89384a3f2ba411e05d3521513414fbbb2199c8", size = 952118, upload-time = "2025-11-04T15:21:03.484Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -858,34 +755,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1003,42 +872,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jmespath"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
-]
-
-[[package]]
-name = "jsonschema"
-version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
-]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1525,88 +1358,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-api"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-proto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2029,41 +1780,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ray"
-version = "2.53.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/99/21986c7f8135dafbf7c49229c52faaa9d2d365db7d86fffe978dde8ee967/ray-2.53.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4db914a0a6dd608fa49c066929a1282745a2dbd73caee67d7b80fe684ca65bdd", size = 69473649, upload-time = "2025-12-20T16:05:40.58Z" },
-    { url = "https://files.pythonhosted.org/packages/70/d9/58b5426a3f11993851db3c93841358cebdddd948153481d355b720f31f9d/ray-2.53.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4108280d8a1cb90d7d68e5c954c35e63b8bb9a4ba15f88c5e7da0e2025647712", size = 71342662, upload-time = "2025-12-20T16:05:46.936Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/05/4aa32370b313481c2d1d41cb53ec786daebdb2ef665b01ef2ac43d9cf457/ray-2.53.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4dbb5fce1364763f29741055f50abe33cf726397141f9cc0e845dd3cc963e455", size = 72188620, upload-time = "2025-12-20T16:05:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/c6/21efe5886898421df20078a333b0984eade7d7aa4bdc68a336f0c66db27e/ray-2.53.0-cp310-cp310-win_amd64.whl", hash = "sha256:90faf630d20b6abf3135997fb3edb5842134aff92e04ee709865db04816d97ef", size = 27200553, upload-time = "2025-12-20T16:05:57.655Z" },
-]
-
-[[package]]
-name = "referencing"
-version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
-]
-
-[[package]]
 name = "regex"
 version = "2026.1.15"
 source = { registry = "https://pypi.org/simple" }
@@ -2117,28 +1833,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rpds-py"
-version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
-    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
-    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2161,18 +1855,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
     { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add onnx->tensorrt export pipeline to n1.6 code. expand from dit to full pipeline. verified both network module output cosine similarity and example robocasa-gr1 task success rate.

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #569, #518, #517.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->

- Full-pipeline ONNX export (ViT, LLM, State/Action Encoder, DiT, Action Decoder)
- TensorRT engine build with BF16/FP8 precision support
- TRT inference integration via policy monkey-patching
- Benchmark and accuracy validation tools
- Pipeline orchestration scripts
- FP8 layer profiling and experimental torch_tensorrt ViT compilation

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/NVIDIA/Isaac-GR00T/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
