### PR TITLE
fix: chat_template loading and spatial_shapes unbound variable in Eagle VL

### DIFF
--- a/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
+++ b/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
@@ -56,7 +56,6 @@ def build_processor(model_name: str, transformers_loading_kwargs: dict) -> Proce
     # apply_chat_template() but AutoProcessor.from_pretrained does not
     # always load it from the bundled chat_template.json / tokenizer_config.json.
     if getattr(processor, "chat_template", None) is None:
-
         for filename in ("chat_template.json", "tokenizer_config.json"):
             template_path = os.path.join(eagle_path, filename)
             if os.path.isfile(template_path):

--- a/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
+++ b/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
@@ -50,7 +50,24 @@ def build_processor(model_name: str, transformers_loading_kwargs: dict) -> Proce
     eagle_path = os.path.join(
         os.path.dirname(__file__), "..", "modules", "nvidia", "Eagle-Block2A-2B-v2"
     )
-    return AutoProcessor.from_pretrained(eagle_path, **transformers_loading_kwargs)
+    processor = AutoProcessor.from_pretrained(eagle_path, **transformers_loading_kwargs)
+
+    # Ensure chat_template is set — transformers >=4.51 requires it for
+    # apply_chat_template() but AutoProcessor.from_pretrained does not
+    # always load it from the bundled chat_template.json / tokenizer_config.json.
+    if getattr(processor, "chat_template", None) is None:
+        import json
+
+        for filename in ("chat_template.json", "tokenizer_config.json"):
+            template_path = os.path.join(eagle_path, filename)
+            if os.path.isfile(template_path):
+                with open(template_path, "r") as f:
+                    data = json.load(f)
+                if "chat_template" in data and data["chat_template"]:
+                    processor.chat_template = data["chat_template"]
+                    break
+
+    return processor
 
 
 class Gr00tN1d6DataCollator:

--- a/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
+++ b/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
@@ -56,7 +56,6 @@ def build_processor(model_name: str, transformers_loading_kwargs: dict) -> Proce
     # apply_chat_template() but AutoProcessor.from_pretrained does not
     # always load it from the bundled chat_template.json / tokenizer_config.json.
     if getattr(processor, "chat_template", None) is None:
-        import json
 
         for filename in ("chat_template.json", "tokenizer_config.json"):
             template_path = os.path.join(eagle_path, filename)

--- a/gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/modeling_eagle3_vl.py
+++ b/gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/modeling_eagle3_vl.py
@@ -349,6 +349,7 @@ class Eagle3_VLForConditionalGeneration(Eagle3_VLPreTrainedModel, GenerationMixi
         return valid_tokens
 
     def extract_feature(self, pixel_values, image_flags=None):
+        spatial_shapes = None
 
         if self.select_layer == -1:
             vision_model_output = self.vision_model(
@@ -359,9 +360,12 @@ class Eagle3_VLForConditionalGeneration(Eagle3_VLPreTrainedModel, GenerationMixi
             if hasattr(vision_model_output, "spatial_shapes"):
                 spatial_shapes = vision_model_output.spatial_shapes
         else:
-            vit_embeds = self.vision_model(
+            vision_model_output = self.vision_model(
                 pixel_values=pixel_values, output_hidden_states=True, return_dict=True
-            ).hidden_states[self.select_layer]
+            )
+            vit_embeds = vision_model_output.hidden_states[self.select_layer]
+            if hasattr(vision_model_output, "spatial_shapes"):
+                spatial_shapes = vision_model_output.spatial_shapes
 
         vit_embeds, spatial_shapes = self.pixel_shuffle_back(vit_embeds, spatial_shapes)
 


### PR DESCRIPTION
## Summary

Two bug fixes for GR00T N1.5/N1.6 inference with `transformers>=4.51`:

### Bug 1: `chat_template` is `None` → `ValueError: Cannot render chat template`

**File**: `gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py`

**Root cause**: `AutoProcessor.from_pretrained()` loads `tokenizer_config.json` which has a simpler template without `<image>` token support. The proper multimodal template lives in `chat_template.json` but is not loaded by the processor.

**Fix**: After `AutoProcessor.from_pretrained()`, check if `chat_template` is `None`. If so, load it from `chat_template.json` (or fall back to `tokenizer_config.json`) in the Eagle model directory.

### Bug 2: `spatial_shapes` unbound → `UnboundLocalError`

**File**: `gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/modeling_eagle3_vl.py`

**Root cause**: In `extract_feature()`, when `select_layer != -1` (GR00T uses `-4`), the `else` branch only grabs `hidden_states[select_layer]` but never captures `spatial_shapes` from `vision_model_output`. Line 366 then uses `spatial_shapes` which was never assigned.

**Fix**: Initialize `spatial_shapes = None` before the branch, and extract it from `vision_model_output` in both `if` and `else` branches.

## Reproduction

```python
from gr00t.model.gr00t_n1d6 import Gr00tN1D6Policy

policy = Gr00tN1D6Policy(
    model_path="nvidia/GR00T-N1.5-3B",
    embodiment_tag="new_embodiment",
)
# Bug 1: ValueError on policy.get_action() due to None chat_template
# Bug 2: UnboundLocalError on spatial_shapes in Eagle VL forward pass
```

## Testing

Verified with 12 integration tests on an NVIDIA L40S GPU (Python 3.10, `transformers==4.51.3`, `gr00t==0.1.0`). All pass after these fixes.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `processing_gr00t_n1d6.py` | +18/-1 | Load `chat_template.json` fallback when `AutoProcessor` misses it |
| `modeling_eagle3_vl.py` | +6/-2 | Initialize `spatial_shapes = None`; extract in both branches |

## Additional note

`chat_template.json` exists in the source tree at `gr00t/model/modules/nvidia/Eagle-Block2A-2B-v2/chat_template.json` but is **not included** in the pip-installed wheel (`gr00t==0.1.0`). Users installing via pip need to manually copy this file. Consider adding it to the wheel packaging.