### PR TITLE
docs(readme): make git-lfs a standalone prerequisite before 'uv sync'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,17 @@ GR00T N1.7 builds on N1.6 with a new VLM backbone and code-level improvements.
 
 GR00T relies on submodules for certain dependencies. Include them when cloning:
 
-**Note:** `git-lfs` is **required** to download parquet data files in `/demo_data`. Install it before cloning: `sudo apt install git-lfs && git lfs install`.
+> **Prerequisite:** `git-lfs` is **required** before you clone. Without it, the LFS-tracked wheels under `scripts/deployment/*/wheels/` and the parquet files in `demo_data/` are fetched as text pointer files instead of real binaries, and `uv sync --python 3.10` later fails with errors such as "Invalid zip file structure" when it tries to read one of those pointer files as a `.whl` archive.
+
+Install and initialise `git-lfs` first:
+
+```sh
+sudo apt update && sudo apt install -y git-lfs
+git lfs install
+```
+
+Then clone the repository:
+
 ```sh
 git clone --recurse-submodules https://github.com/NVIDIA/Isaac-GR00T
 cd Isaac-GR00T
@@ -120,6 +130,12 @@ If you've already cloned without submodules, initialize them separately:
 
 ```sh
 git submodule update --init --recursive
+```
+
+If you've already cloned without `git-lfs` installed, install it as above and then pull the actual binaries into your checkout before continuing:
+
+```sh
+git lfs pull
 ```
 
 ### Set Up the Environment


### PR DESCRIPTION
## Summary

Closes #642.

The current README instructs readers to install `git-lfs` as a single inline note inside the "Clone the Repository" section:

> **Note:** \`git-lfs\` is **required** to download parquet data files in \`/demo_data\`. Install it before cloning: \`sudo apt install git-lfs && git lfs install\`.

It's easy to miss (sits on one line between the section header and the clone command), and it *understates* the impact — besides `demo_data/**/*.parquet`, `.gitattributes` also tracks the per-platform CUDA wheels:

```
scripts/deployment/dgpu/wheels/*.whl filter=lfs ...
scripts/deployment/orin/wheels/*.whl filter=lfs ...
scripts/deployment/spark/wheels/*.whl filter=lfs ...
```

If a user clones without `git-lfs` installed, those wheels end up on disk as text pointer files. Then the very next step in the README, `uv sync --python 3.10`, reads one of them while resolving the `flash-attn` path dependency and fails with the stack trace in #642:

```
error: Failed to generate package metadata for flash-attn==2.7.4.post1 @ path+scripts/deployment/dgpu/wheels/flash_attn-2.7.4.post1-cp310-cp310-linux_aarch64.whl
  Caused by: Failed to extract archive: ...
  Caused by: Invalid zip file structure
  Caused by: Encountered an unexpected header (actual: 0x73726576, expected: 0x4034b50).
```

## Changes

Restructures "Clone the Repository" so `git-lfs` is impossible to miss:

1. Promotes the existing inline note into a blockquote callout that explicitly names the wheels under `scripts/deployment/*/wheels/` and explains the `uv sync` failure mode.
2. Moves `sudo apt update && sudo apt install -y git-lfs` / `git lfs install` into their own code block **before** `git clone --recurse-submodules …`.
3. Adds a short "already cloned without git-lfs?" recovery snippet at the end with `git lfs pull` so users who already hit the failure can recover without re-cloning.

No other sections are touched.

## Testing

- README-only change.
- Verified `.gitattributes` tracking of the wheels listed above, and confirmed on a fresh clone without `git-lfs` that `scripts/deployment/dgpu/wheels/flash_attn-*.whl` appears as `ASCII text` rather than a real zip, matching the reporter's failure mode.