### PR TITLE
fix(loader): detect LeRobot v3.0 datasets and guide users to bundled v3->v2 converter

### DIFF
--- a/gr00t/data/dataset/lerobot_episode_loader.py
+++ b/gr00t/data/dataset/lerobot_episode_loader.py
@@ -164,6 +164,30 @@ class LeRobotEpisodeLoader:
 
         # Load episode metadata (one episode per line)
         episodes_path = meta_dir / LEROBOT_EPISODES_FILENAME
+        if not episodes_path.exists():
+            # Detect LeRobot v3.0 datasets: they keep per-chunk episode metadata
+            # under meta/episodes/chunk-XXX/file-YYY.parquet instead of a single
+            # meta/episodes.jsonl file. Surface an actionable error pointing
+            # users at the v3 -> v2 converter shipped in this repo.
+            v3_episodes_dir = meta_dir / "episodes"
+            codebase_version = self.info_meta.get("codebase_version", "unknown")
+            if v3_episodes_dir.exists() or str(codebase_version).startswith("v3"):
+                raise FileNotFoundError(
+                    f"{episodes_path} not found. The dataset at "
+                    f"'{self.dataset_path}' looks like LeRobot codebase_version "
+                    f"'{codebase_version}' (v3.0 layout), which is not yet "
+                    f"natively supported by the GR00T loader (expects v2.1).\n\n"
+                    f"Convert it with the helper shipped in this repo:\n"
+                    f"    cd scripts/lerobot_conversion\n"
+                    f"    uv venv && source .venv/bin/activate\n"
+                    f"    uv pip install -e .\n"
+                    f"    python convert_v3_to_v2.py --repo-id <hf-org/dataset-name>\n\n"
+                    f"See scripts/lerobot_conversion/README.md for details."
+                )
+            raise FileNotFoundError(
+                f"{episodes_path} not found for dataset {self.dataset_path}. "
+                f"Expected a LeRobot v2.1 layout (meta/episodes.jsonl)."
+            )
         with open(episodes_path, "r") as f:
             self.episodes_metadata = [json.loads(line) for line in f]
 


### PR DESCRIPTION
## What

`LeRobotEpisodeLoader._load_metadata` assumes a LeRobot v2.1 layout (single `meta/episodes.jsonl`). When pointed at a v3.0 dataset (e.g. [`lerobot/svla_so101_pickplace`](https://huggingface.co/datasets/lerobot/svla_so101_pickplace), [`BobShan/double_folding_towel_v3.0`](https://huggingface.co/datasets/BobShan/double_folding_towel_v3.0)) the loader currently dies with a bare `FileNotFoundError` on `meta/episodes.jsonl`, because v3 keeps per-chunk episode metadata under `meta/episodes/chunk-XXX/file-YYY.parquet` instead.

This is a real footgun — the LeRobot team is steadily migrating canonical datasets to v3.0, so users following any GR00T-N1.5/N1.7 finetuning recipe with the latest dataset releases hit a 30-second crash with no hint at the cause.

## How

Detect the v3.0 layout in two ways:
1. `meta/episodes/` directory exists, **or**
2. `info.json["codebase_version"]` starts with `v3`.

When detected, raise a targeted `FileNotFoundError` that points the user at the converter already shipped in this repo (`scripts/lerobot_conversion/convert_v3_to_v2.py`), including the exact command to run.

Behaviour for v2.1 datasets is **unchanged** — the new code only fires when `meta/episodes.jsonl` is missing.

## Diff

```python
# gr00t/data/dataset/lerobot_episode_loader.py
episodes_path = meta_dir / LEROBOT_EPISODES_FILENAME
+ if not episodes_path.exists():
+     v3_episodes_dir = meta_dir / "episodes"
+     codebase_version = self.info_meta.get("codebase_version", "unknown")
+     if v3_episodes_dir.exists() or str(codebase_version).startswith("v3"):
+         raise FileNotFoundError(
+             f"... v3.0 layout detected, run convert_v3_to_v2.py ..."
+         )
+     raise FileNotFoundError(
+         f"{episodes_path} not found for dataset {self.dataset_path}. "
+         f"Expected a LeRobot v2.1 layout (meta/episodes.jsonl)."
+     )
with open(episodes_path, "r") as f:
    self.episodes_metadata = [json.loads(line) for line in f]
```

## Repro of the original failure

```bash
hf download lerobot/svla_so101_pickplace --repo-type dataset --local-dir /tmp/svla
python -c "from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader; \LeRobotEpisodeLoader('/tmp/svla', modality_configs={})"
# before: FileNotFoundError: [Errno 2] No such file or directory: '/tmp/svla/meta/episodes.jsonl'
# after:  FileNotFoundError: ... v3.0 layout, which is not yet natively supported.
#         Convert it with the helper shipped in this repo:
#             cd scripts/lerobot_conversion
#             uv venv && source .venv/bin/activate
#             uv pip install -e .
#             python convert_v3_to_v2.py --repo-id <hf-org/dataset-name>
```

## Notes / future work

- This PR is intentionally minimal — it does **not** add native v3.0 support, just a clear pointer to the existing converter.
- A follow-up could call the converter automatically on load, but I'd rather keep that opt-in given v3 -> v2 conversion rewrites the dataset on disk.
- Tested locally on Linux aarch64 (Thor), Python 3.12.

cc @ ## Checklist

- [x] No public API change for valid v2.1 datasets
- [x] No new dependencies
- [x] Syntactically validated (`python -c "import ast; ast.parse(...)"`)
- [x] Branch is rebased on `main` (`3df8b38`)
