### PR TITLE
Make N1.6 letterbox transforms opt-in and fix 1d6 tests

### DIFF
--- a/gr00t/configs/model/gr00t_n1d6.py
+++ b/gr00t/configs/model/gr00t_n1d6.py
@@ -45,6 +45,7 @@ class Gr00tN1d6Config(PretrainedConfig):
     random_rotation_angle: int | None = None
     color_jitter_params: dict[str, float] | None = None
     use_albumentations_transforms: bool = True
+    letter_box_transform: bool = False
     # Extra augmentation config (mask-based and others).
     extra_augmentation_config: dict | None = None
     formalize_language: bool = True

--- a/gr00t/data/dataset/sharded_mixture_dataset.py
+++ b/gr00t/data/dataset/sharded_mixture_dataset.py
@@ -42,13 +42,19 @@ def merge_statistics(
     # Initialize overall statistics dict
     overall_stats: dict[str, dict[str, list[float]]] = {}
 
-    # Process each modality (e.g., "state", "action")
-    for modality in per_dataset_stats[0]:
+    # Process each modality (e.g., "state", "action"). An entry is a real
+    # stats group iff it carries a "mean" field; anything else is sidecar
+    # metadata that producers may co-locate at the top level (e.g. the
+    # __fingerprints__ cache map written by generate_rel_stats) and must be
+    # skipped rather than merged.
+    for modality, modality_stats in per_dataset_stats[0].items():
+        if not isinstance(modality_stats, dict) or "mean" not in modality_stats:
+            continue
         # Get dimensionality from first dataset (assumed consistent)
         dim = (
-            [len(per_dataset_stats[0][modality]["mean"])]
+            [len(modality_stats["mean"])]
             if not is_relative_stats
-            else np.array(per_dataset_stats[0][modality]["mean"]).shape
+            else np.array(modality_stats["mean"]).shape
         )
 
         # Initialize accumulators for weighted mean and variance computation

--- a/gr00t/eval/sim/LIBERO/setup_libero.sh
+++ b/gr00t/eval/sim/LIBERO/setup_libero.sh
@@ -22,7 +22,10 @@ uv pip install -e $LIBERO_REPO --config-settings editable_mode=compat
 uv pip install --editable $PROJECT_REPO --no-deps
 uv pip install torch==2.5.1 torchvision==0.20.1 pydantic av tianshou==0.5.1 tyro pandas dm_tree einops==0.8.1 albumentations==1.4.18 zmq
 uv pip install transformers==4.51.3 msgpack==1.1.0 msgpack-numpy==0.4.8 gymnasium==0.29.1
-uv pip install numpy==1.26.4
+# Pin mujoco: robosuite 1.4.0 (pulled by LIBERO's requirements) calls
+# mj_fullM(model, dst, M), whose signature changed in mujoco 3.10.0 to
+# mj_fullM(model, data, dst). Leaving mujoco unpinned breaks env creation.
+uv pip install numpy==1.26.4 mujoco==3.3.1
 
 uv pip install --editable "$PROJECT_REPO" --no-deps
 

--- a/gr00t/model/gr00t_n1d6/image_augmentations.py
+++ b/gr00t/model/gr00t_n1d6/image_augmentations.py
@@ -358,6 +358,7 @@ def build_image_transformations_albumentations(
     shortest_image_edge,
     crop_fraction,
     extra_augmentation_config: dict | None = None,
+    letter_box_transform: bool = False,
 ):
     """
     Build albumentations-based image transformations equivalent to the torchvision version.
@@ -396,12 +397,16 @@ def build_image_transformations_albumentations(
 
     # Training transforms (using ReplayCompose for consistent augmentation across views)
     # Use SmallestMaxSize to preserve aspect ratios, with INTER_AREA for antialiasing
-    train_transform_list = [
-        LetterBoxPad(),
-        A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
-        FractionalRandomCrop(crop_fraction=fraction_to_use),
-        A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
-    ]
+    train_transform_list = []
+    if letter_box_transform:
+        train_transform_list.append(LetterBoxPad())
+    train_transform_list.extend(
+        [
+            A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
+            FractionalRandomCrop(crop_fraction=fraction_to_use),
+            A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
+        ]
+    )
 
     if random_rotation_angle is not None and random_rotation_angle != 0:
         train_transform_list.append(A.Rotate(limit=random_rotation_angle, p=1.0))
@@ -456,14 +461,17 @@ def build_image_transformations_albumentations(
 
     # Evaluation transforms (deterministic, no extra augmentations)
     # Use SmallestMaxSize to preserve aspect ratios, with INTER_AREA for antialiasing
-    eval_transform = A.Compose(
+    eval_transform_list = []
+    if letter_box_transform:
+        eval_transform_list.append(LetterBoxPad())
+    eval_transform_list.extend(
         [
-            LetterBoxPad(),
             A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
             FractionalCenterCrop(crop_fraction=fraction_to_use),
             A.SmallestMaxSize(max_size=max_size, interpolation=cv2.INTER_AREA),
         ]
     )
+    eval_transform = A.Compose(eval_transform_list)
 
     return train_transform, eval_transform
 
@@ -528,7 +536,11 @@ class LetterBoxTransform:
 
 
 def build_image_transformations(
-    image_target_size, image_crop_size, random_rotation_angle, color_jitter_params
+    image_target_size,
+    image_crop_size,
+    random_rotation_angle,
+    color_jitter_params,
+    letter_box_transform: bool = False,
 ):
     """
     Build torchvision-based image transformations.
@@ -542,14 +554,17 @@ def build_image_transformations(
     Returns:
         tuple: (train_transform, eval_transform) - torchvision transforms
     """
-    transform_list = [
-        transforms.ToImage(),
-        LetterBoxTransform(),
-        # transforms.ToDtype(torch.get_default_dtype(), scale=True),
-        transforms.Resize(size=image_target_size),
-        transforms.RandomCrop(size=image_crop_size),
-        transforms.Resize(size=image_target_size),
-    ]
+    transform_list = [transforms.ToImage()]
+    if letter_box_transform:
+        transform_list.append(LetterBoxTransform())
+    transform_list.extend(
+        [
+            # transforms.ToDtype(torch.get_default_dtype(), scale=True),
+            transforms.Resize(size=image_target_size),
+            transforms.RandomCrop(size=image_crop_size),
+            transforms.Resize(size=image_target_size),
+        ]
+    )
     if random_rotation_angle is not None and random_rotation_angle != 0:
         transform_list.append(
             transforms.RandomRotation(degrees=[-random_rotation_angle, random_rotation_angle])
@@ -557,14 +572,16 @@ def build_image_transformations(
     if color_jitter_params is not None:
         transform_list.append(transforms.ColorJitter(**color_jitter_params))
     train_image_transform = transforms.Compose(transform_list)
-    eval_image_transform = transforms.Compose(
+    eval_transform_list = [transforms.ToImage()]
+    if letter_box_transform:
+        eval_transform_list.append(LetterBoxTransform())
+    eval_transform_list.extend(
         [
-            transforms.ToImage(),
             # transforms.ToDtype(torch.get_default_dtype(), scale=True),
-            LetterBoxTransform(),
             transforms.Resize(size=image_target_size),
             transforms.CenterCrop(size=image_crop_size),
             transforms.Resize(size=image_target_size),
         ]
     )
+    eval_image_transform = transforms.Compose(eval_transform_list)
     return train_image_transform, eval_image_transform

--- a/gr00t/model/gr00t_n1d6/image_augmentations.py
+++ b/gr00t/model/gr00t_n1d6/image_augmentations.py
@@ -317,34 +317,21 @@ class LetterBoxPad(A.DualTransform):
     def __init__(self, p: float = 1.0, always_apply: bool | None = None):
         super().__init__(p=p, always_apply=always_apply)
 
-    def apply(
-        self,
-        img: np.ndarray,
-        pad_top: int = 0,
-        pad_bottom: int = 0,
-        pad_left: int = 0,
-        pad_right: int = 0,
-        **params,
-    ) -> np.ndarray:
-        if pad_top == 0 and pad_bottom == 0 and pad_left == 0 and pad_right == 0:
-            return img
-        return cv2.copyMakeBorder(
-            img, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT, value=0
-        )
-
-    def get_params_dependent_on_data(self, params, data) -> dict[str, int]:
-        h, w = params["shape"][:2]
+    def apply(self, img: np.ndarray, **params) -> np.ndarray:
+        # Derive padding from the current image so A.ReplayCompose works with mixed-size views.
+        h, w = img.shape[:2]
         if h == w:
-            return {"pad_top": 0, "pad_bottom": 0, "pad_left": 0, "pad_right": 0}
+            return img
         max_dim = max(h, w)
         pad_h = max_dim - h
         pad_w = max_dim - w
-        return {
-            "pad_top": pad_h // 2,
-            "pad_bottom": pad_h - pad_h // 2,
-            "pad_left": pad_w // 2,
-            "pad_right": pad_w - pad_w // 2,
-        }
+        pad_top = pad_h // 2
+        pad_bottom = pad_h - pad_top
+        pad_left = pad_w // 2
+        pad_right = pad_w - pad_left
+        return cv2.copyMakeBorder(
+            img, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT, value=0
+        )
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ()

--- a/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
+++ b/gr00t/model/gr00t_n1d6/processing_gr00t_n1d6.py
@@ -132,6 +132,7 @@ class Gr00tN1d6Processor(BaseProcessor):
         use_relative_action: bool = False,
         embodiment_id_mapping: dict[str, int] | None = None,
         transformers_loading_kwargs: dict = {"trust_remote_code": True},
+        letter_box_transform: bool = False,
     ):
         self.modality_configs = parse_modality_configs(modality_configs)
 
@@ -151,6 +152,7 @@ class Gr00tN1d6Processor(BaseProcessor):
         self.apply_sincos_state_encoding = apply_sincos_state_encoding
         self.use_relative_action = use_relative_action
         self.extra_augmentation_config = extra_augmentation_config
+        self.letter_box_transform = letter_box_transform
 
         # Save VLM settings
         self.formalize_language = formalize_language
@@ -189,11 +191,16 @@ class Gr00tN1d6Processor(BaseProcessor):
                     shortest_image_edge,
                     crop_fraction,
                     extra_augmentation_config=self.extra_augmentation_config,
+                    letter_box_transform=self.letter_box_transform,
                 )
             )
         else:
             self.train_image_transform, self.eval_image_transform = build_image_transformations(
-                image_target_size, image_crop_size, random_rotation_angle, color_jitter_params
+                image_target_size,
+                image_crop_size,
+                random_rotation_angle,
+                color_jitter_params,
+                letter_box_transform=self.letter_box_transform,
             )
         self._collator = self.data_collator_class(
             model_name=model_name,
@@ -464,6 +471,7 @@ class Gr00tN1d6Processor(BaseProcessor):
                 "color_jitter_params": self.color_jitter_params,
                 "shortest_image_edge": self.shortest_image_edge,
                 "crop_fraction": self.crop_fraction,
+                "letter_box_transform": self.letter_box_transform,
                 # VLM settings
                 "model_name": self.model_name,
                 "model_type": self.model_type,
@@ -529,6 +537,7 @@ class Gr00tN1d6Processor(BaseProcessor):
                 "color_jitter_params",
                 "use_relative_action",
                 "extra_augmentation_config",
+                "letter_box_transform",
             ]
             for key in override_keys:
                 if key in kwargs:

--- a/gr00t/model/gr00t_n1d6/setup.py
+++ b/gr00t/model/gr00t_n1d6/setup.py
@@ -120,6 +120,7 @@ class Gr00tN1d6Pipeline(ModelPipeline):
 
     def _create_dataset(self, save_cfg_dir: Path):
         """Create appropriate dataset based on task and mode."""
+        letter_box_transform = self.model_config.letter_box_transform
 
         if self.config.training.start_from_checkpoint is not None:
             processor = AutoProcessor.from_pretrained(
@@ -139,6 +140,7 @@ class Gr00tN1d6Pipeline(ModelPipeline):
                 extra_augmentation_config=self.model_config.extra_augmentation_config,
                 shortest_image_edge=self.model_config.shortest_image_edge,
                 crop_fraction=self.model_config.crop_fraction,
+                letter_box_transform=letter_box_transform,
                 transformers_loading_kwargs=self.transformers_loading_kwargs,
                 use_alternate_vl_dit=self.model_config.use_alternate_vl_dit,
                 use_relative_action=self.model_config.use_relative_action,
@@ -164,6 +166,7 @@ class Gr00tN1d6Pipeline(ModelPipeline):
                 extra_augmentation_config=self.model_config.extra_augmentation_config,
                 shortest_image_edge=self.model_config.shortest_image_edge,
                 crop_fraction=self.model_config.crop_fraction,
+                letter_box_transform=letter_box_transform,
                 use_relative_action=self.model_config.use_relative_action,
                 transformers_loading_kwargs=self.transformers_loading_kwargs,
             )

--- a/tests/gr00t/data/test_sharded_mixture_dataset.py
+++ b/tests/gr00t/data/test_sharded_mixture_dataset.py
@@ -1,0 +1,9 @@
+from gr00t.data.dataset.sharded_mixture_dataset import merge_statistics
+
+
+def test_merge_statistics_skips_relative_stats_sidecar_only_input():
+    stats = [{"__fingerprints__": {}}]
+
+    merged = merge_statistics(stats, [1.0], is_relative_stats=True)
+
+    assert merged == {}

--- a/tests/gr00t/model/test_variable_image_size.py
+++ b/tests/gr00t/model/test_variable_image_size.py
@@ -1,14 +1,9 @@
-"""
-Test that GR00T inference can handle variable input image sizes.
-
-Adapted from https://github.com/NVIDIA/Isaac-GR00T/issues/541
-Tests the fix for: "stack expects each tensor to be equal size"
-when different camera views have different aspect ratios.
-"""
+"""Test N1.6 image transform sizing behavior across torchvision and albumentations paths."""
 
 from pathlib import Path
 
 from gr00t.model.gr00t_n1d6.image_augmentations import (
+    apply_with_replay,
     build_image_transformations,
     build_image_transformations_albumentations,
 )
@@ -30,12 +25,33 @@ class TestTorchvisionTransforms:
     def setup_method(self):
         self.image_target_size = [256, 256]
         self.image_crop_size = [224, 224]
-        _, self.eval_transform = build_image_transformations(
+        self.train_transform, self.eval_transform = build_image_transformations(
             image_target_size=self.image_target_size,
             image_crop_size=self.image_crop_size,
             random_rotation_angle=None,
             color_jitter_params=None,
         )
+
+    def test_letterbox_transform_is_disabled_by_default(self):
+        transform_names = [
+            type(transform).__name__
+            for transform in [*self.train_transform.transforms, *self.eval_transform.transforms]
+        ]
+        assert "LetterBoxTransform" not in transform_names
+
+    def test_letterbox_transform_can_be_enabled(self):
+        train_transform, eval_transform = build_image_transformations(
+            image_target_size=self.image_target_size,
+            image_crop_size=self.image_crop_size,
+            random_rotation_angle=None,
+            color_jitter_params=None,
+            letter_box_transform=True,
+        )
+        transform_names = [
+            type(transform).__name__
+            for transform in [*train_transform.transforms, *eval_transform.transforms]
+        ]
+        assert "LetterBoxTransform" in transform_names
 
     def test_same_size_images(self):
         img1 = Image.fromarray(np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8))
@@ -65,10 +81,10 @@ class TestTorchvisionTransforms:
 
 
 class TestAlbumentationsTransforms:
-    """Test that albumentations eval transform produces consistent sizes."""
+    """Test that albumentations preserves aspect ratio without letterboxing."""
 
     def setup_method(self):
-        _, self.eval_transform = build_image_transformations_albumentations(
+        self.train_transform, self.eval_transform = build_image_transformations_albumentations(
             image_target_size=None,
             image_crop_size=None,
             random_rotation_angle=None,
@@ -81,6 +97,68 @@ class TestAlbumentationsTransforms:
         result = self.eval_transform(image=np.array(pil_img))
         return torch.from_numpy(result["image"]).permute(2, 0, 1)
 
+    def test_letterbox_pad_is_not_in_transform_pipeline(self):
+        transform_names = [
+            type(transform).__name__
+            for transform in [*self.train_transform.transforms, *self.eval_transform.transforms]
+        ]
+        assert "LetterBoxPad" not in transform_names
+
+    def test_letterbox_pad_can_be_enabled(self):
+        train_transform, eval_transform = build_image_transformations_albumentations(
+            image_target_size=None,
+            image_crop_size=None,
+            random_rotation_angle=None,
+            color_jitter_params=None,
+            shortest_image_edge=256,
+            crop_fraction=0.95,
+            letter_box_transform=True,
+        )
+        transform_names = [
+            type(transform).__name__
+            for transform in [*train_transform.transforms, *eval_transform.transforms]
+        ]
+        assert "LetterBoxPad" in transform_names
+        assert type(train_transform.transforms[0]).__name__ == "LetterBoxPad"
+        assert type(eval_transform.transforms[0]).__name__ == "LetterBoxPad"
+
+    def test_letterbox_pad_makes_mixed_aspect_images_stackable(self):
+        _, eval_transform = build_image_transformations_albumentations(
+            image_target_size=None,
+            image_crop_size=None,
+            random_rotation_angle=None,
+            color_jitter_params=None,
+            shortest_image_edge=256,
+            crop_fraction=0.95,
+            letter_box_transform=True,
+        )
+
+        def apply(pil_img):
+            result = eval_transform(image=np.array(pil_img))
+            return torch.from_numpy(result["image"]).permute(2, 0, 1)
+
+        img_square = Image.fromarray(np.random.randint(0, 255, (480, 480, 3), dtype=np.uint8))
+        img_wide = Image.fromarray(np.random.randint(0, 255, (240, 640, 3), dtype=np.uint8))
+        out_sq = apply(img_square)
+        out_wide = apply(img_wide)
+        assert out_sq.shape == out_wide.shape, f"Shape mismatch: {out_sq.shape} vs {out_wide.shape}"
+        torch.stack([out_sq, out_wide])
+
+    def test_letterbox_pad_train_replay_handles_mixed_aspect_views(self):
+        train_transform, _ = build_image_transformations_albumentations(
+            image_target_size=None,
+            image_crop_size=None,
+            random_rotation_angle=None,
+            color_jitter_params=None,
+            shortest_image_edge=256,
+            crop_fraction=0.95,
+            letter_box_transform=True,
+        )
+        img_square = Image.fromarray(np.random.randint(0, 255, (480, 480, 3), dtype=np.uint8))
+        img_wide = Image.fromarray(np.random.randint(0, 255, (240, 640, 3), dtype=np.uint8))
+        transformed, _ = apply_with_replay(train_transform, [img_square, img_wide])
+        torch.stack(transformed)
+
     def test_same_size_images(self):
         img1 = Image.fromarray(np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8))
         img2 = Image.fromarray(np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8))
@@ -89,23 +167,22 @@ class TestAlbumentationsTransforms:
         assert out1.shape == out2.shape, f"Shape mismatch: {out1.shape} vs {out2.shape}"
         torch.stack([out1, out2])
 
-    def test_variable_size_images(self):
+    def test_same_aspect_variable_size_images(self):
         img_4_3 = Image.fromarray(np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8))
-        img_16_9 = Image.fromarray(np.random.randint(0, 255, (360, 640, 3), dtype=np.uint8))
+        img_4_3_small = Image.fromarray(np.random.randint(0, 255, (240, 320, 3), dtype=np.uint8))
         out_4_3 = self._apply(img_4_3)
-        out_16_9 = self._apply(img_16_9)
-        assert out_4_3.shape == out_16_9.shape, (
-            f"Shape mismatch for different aspect ratios: {out_4_3.shape} vs {out_16_9.shape}"
+        out_4_3_small = self._apply(img_4_3_small)
+        assert out_4_3.shape == out_4_3_small.shape, (
+            f"Shape mismatch for same aspect ratios: {out_4_3.shape} vs {out_4_3_small.shape}"
         )
-        torch.stack([out_4_3, out_16_9])
+        torch.stack([out_4_3, out_4_3_small])
 
-    def test_square_and_wide_images(self):
+    def test_mixed_aspect_images_preserve_different_shapes(self):
         img_square = Image.fromarray(np.random.randint(0, 255, (480, 480, 3), dtype=np.uint8))
         img_wide = Image.fromarray(np.random.randint(0, 255, (240, 640, 3), dtype=np.uint8))
         out_sq = self._apply(img_square)
         out_wide = self._apply(img_wide)
-        assert out_sq.shape == out_wide.shape, f"Shape mismatch: {out_sq.shape} vs {out_wide.shape}"
-        torch.stack([out_sq, out_wide])
+        assert out_sq.shape != out_wide.shape
 
 
 # ---- Processor-level tests (using fixture config, no checkpoint needed) ----
@@ -124,11 +201,12 @@ class TestProcessorVariableImageSize:
     """Test full _get_vlm_inputs path with variable image sizes."""
 
     def test_variable_size_vlm_inputs(self, processor):
-        """Test _get_vlm_inputs with different aspect ratio images across views."""
+        """Test _get_vlm_inputs with same-aspect variable-size images across views."""
         embodiment_tag = "libero_panda"
         image_keys = processor.modality_configs[embodiment_tag]["video"].modality_keys
 
-        # Create mock images with different sizes per view
+        # Albumentations preserves aspect ratio, so views in one sample must share aspect ratio
+        # before the processor stacks them.
         mock_images = {}
         for i, key in enumerate(image_keys):
             if i % 2 == 0:
@@ -137,7 +215,7 @@ class TestProcessorVariableImageSize:
                 ]
             else:
                 mock_images[key] = [
-                    Image.fromarray(np.random.randint(0, 255, (360, 640, 3), dtype=np.uint8))
+                    Image.fromarray(np.random.randint(0, 255, (240, 320, 3), dtype=np.uint8))
                 ]
 
         vlm_inputs = processor._get_vlm_inputs(
@@ -150,6 +228,31 @@ class TestProcessorVariableImageSize:
 
         assert "vlm_content" in vlm_inputs
         assert len(vlm_inputs["vlm_content"]["images"]) == len(image_keys)
+
+    def test_mixed_aspect_vlm_inputs_raise(self, processor):
+        """Albumentations preserves aspect ratio, so mixed-aspect views are not stackable."""
+        embodiment_tag = "libero_panda"
+        image_keys = processor.modality_configs[embodiment_tag]["video"].modality_keys
+
+        mock_images = {}
+        for i, key in enumerate(image_keys):
+            if i % 2 == 0:
+                mock_images[key] = [
+                    Image.fromarray(np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8))
+                ]
+            else:
+                mock_images[key] = [
+                    Image.fromarray(np.random.randint(0, 255, (360, 640, 3), dtype=np.uint8))
+                ]
+
+        with pytest.raises(RuntimeError, match="stack expects each tensor to be equal size"):
+            processor._get_vlm_inputs(
+                image_keys=image_keys,
+                images=mock_images,
+                image_transform=processor.eval_image_transform,
+                language="pick up the object",
+                masks=None,
+            )
 
     def test_same_size_vlm_inputs(self, processor):
         """Test _get_vlm_inputs with same size images (regression test)."""


### PR DESCRIPTION
## Summary

Make the N1.6 letterbox image transform opt-in on the `gr00t_1d6` branch, matching the behavior already used by the newer release line. This avoids injecting empty padded pixels into non-square-aspect training inputs unless a caller explicitly asks for that behavior.

## Changes

- Default `letter_box_transform` to `False` in the N1.6 model config and processor setup.
- Keep LetterBoxPad/LetterBoxTransform available behind the existing config flag for compatibility.
- Fix LetterBoxPad replay behavior so padding is computed from each current image, rather than reusing replay params from the first image.
- Update variable image size tests to cover default aspect-ratio preservation and opt-in square padding.
- Skip sidecar-only relative stats entries like `__fingerprints__` in `merge_statistics()`.
- Pin LIBERO's MuJoCo runtime below the `mj_fullM` API break that affects `robosuite==1.4.0`.

## Validation

- `python -m py_compile gr00t/data/dataset/sharded_mixture_dataset.py gr00t/model/gr00t_n1d6/image_augmentations.py tests/gr00t/data/test_sharded_mixture_dataset.py tests/gr00t/model/test_variable_image_size.py`
- `git diff --check`
- Mirrored release-branch CI passed for build, lint, CPU tests, GPU tests, and sync checks.