### PR TITLE
Fix LIBERO evaluation to execute predicted action chunks

### DIFF
--- a/examples/Libero/README.md
+++ b/examples/Libero/README.md
@@ -18,17 +18,13 @@ Evaluation is performed using [`run_libero_eval.py`](https://github.com/NVIDIA/I
 
 | Task      | Success rate       | max_steps | grad_accum_steps | batch_size | Data config                                                     |                   Checkpoint                  |
 |-----------|--------------------|-----------|------------------|------------|-----------------------------------------------------------------|-----------------------------------------------|
-| Spatial   | 46/50 (92%)        | 20K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-spatial-posttrain|
-| Goal      | 43/50 (86%)        | 20K       | 4                | 72         | examples.Libero.custom_data_config:LiberoDataConfigMeanStd      |youliangtan/gr00t-n1.5-libero-goal-posttrain|
-| Object    | 46/50 (92%)        | 20K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-object-posttrain|
+| Spatial   | 98/100 (98%)       | 20K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-spatial-posttrain|
+| Goal      | 94/100 (94%)       | 20K       | 4                | 72         | examples.Libero.custom_data_config:LiberoDataConfigMeanStd      |youliangtan/gr00t-n1.5-libero-goal-posttrain|
+| Object    | 99/100 (99%)       | 20K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-object-posttrain|
 | Libero-90 | 402/450 (89.3%)    | 60K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-90-posttrain|
-| Long      | 38/50 (76%)        | 60K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-long-posttrain|
+| Long      | 88/100 (88%)       | 60K       | 1                | 128        | examples.Libero.custom_data_config:LiberoDataConfig             |youliangtan/gr00t-n1.5-libero-long-posttrain|
 
-
-
-
-
-> Note: The results reported above were obtained with minimal hyperparameter tuning and are intended primarily for demonstration purposes. More comprehensive studies have fine-tuned GR00T on LIBERO and achieved substantially higher performance. For example, see Table 3 in this [paper](https://arxiv.org/pdf/2508.21112).
+> Note: Spatial, Goal, Object, and Long were evaluated with 10 trials per task and an action horizon of 8. The Libero-90 result retains its original evaluation setting. These results were obtained with minimal hyperparameter tuning and are intended primarily for demonstration purposes. More comprehensive studies have fine-tuned GR00T on LIBERO and achieved substantially higher performance. For example, see Table 3 in this [paper](https://arxiv.org/pdf/2508.21112).
 ----
 
 To evaluate, first start the inference server with our provided checkpoint:
@@ -74,7 +70,10 @@ pip install robosuite==1.4.0
 Then run the evaluation:
 ```bash
 cd examples/Libero/eval
-python run_libero_eval.py --task_suite_name libero_spatial
+python run_libero_eval.py \
+    --task_suite_name libero_spatial \
+    --action_horizon 8 \
+    --num_trials_per_task 10
 ```
 
 ----

--- a/examples/Libero/eval/run_libero_eval.py
+++ b/examples/Libero/eval/run_libero_eval.py
@@ -57,6 +57,7 @@ class GenerateConfig:
     #################################################################################################################
     task_suite_name: str = "libero_spatial"          # Task suite. Options: libero_spatial, libero_object, libero_goal, libero_10, libero_90
     num_steps_wait: int = 10                         # Number of steps to wait for objects to stabilize in sim
+    action_horizon: int = 8                          # Number of actions to execute from each predicted action chunk
     num_trials_per_task: int = 5                    # Number of rollouts per task
     #################################################################################################################
     # fmt: on
@@ -92,10 +93,18 @@ class GR00TPolicy:
 
     def get_action(self, observation_dict, lang: str):
         """Get action from GR00T policy given observation and language instruction."""
+        return self.get_action_chunk(observation_dict, lang)[0]
+
+    def get_action_chunk(self, observation_dict, lang: str) -> list[np.ndarray]:
+        """Get and convert the complete action chunk predicted by the policy."""
         obs_dict = self._process_observation(observation_dict, lang)
         # summarize_obs(obs_dict)
         action_chunk = self.policy.get_action(obs_dict)
-        return self._convert_to_libero_action(action_chunk, 0)
+        first_action_key = f"action.{self.action_keys[0]}"
+        chunk_horizon = np.asarray(action_chunk[first_action_key]).shape[0]
+        return [
+            self._convert_to_libero_action(action_chunk, idx) for idx in range(chunk_horizon)
+        ]
 
     def _process_observation(self, obs, lang: str):
         """Convert Libero observation to GR00T format."""
@@ -141,6 +150,9 @@ class GR00TPolicy:
 
 
 def eval_libero(cfg: GenerateConfig) -> None:
+    if cfg.action_horizon < 1:
+        raise ValueError(f"action_horizon must be at least 1, got {cfg.action_horizon}")
+
     # Initialize LIBERO task suite
     benchmark_dict = benchmark.get_benchmark_dict()
     task_suite = benchmark_dict[cfg.task_suite_name]()
@@ -148,6 +160,7 @@ def eval_libero(cfg: GenerateConfig) -> None:
     print(f"Task suite: {cfg.task_suite_name}")
     log_file = open(f"{log_dir}/libero_eval_{cfg.task_suite_name}.log", "w")
     log_file.write(f"Task suite: {cfg.task_suite_name}\n")
+    log_file.write(f"Action horizon: {cfg.action_horizon}\n")
 
     # Start evaluation
     total_episodes, total_successes = 0, 0
@@ -179,6 +192,7 @@ def eval_libero(cfg: GenerateConfig) -> None:
             t = 0
             top_view = []
             wrist_view = []
+            done = False
             if cfg.task_suite_name == "libero_spatial":
                 max_steps = 220  # longest training demo has 193 steps
             elif cfg.task_suite_name == "libero_object":
@@ -201,26 +215,31 @@ def eval_libero(cfg: GenerateConfig) -> None:
                         t += 1
                         continue
 
-                    # # Get preprocessed image
-                    img, wrist_img = get_libero_image(obs)
-
-                    # # Save preprocessed image for replay video
-                    top_view.append(img)
-                    wrist_view.append(wrist_img)
-
-                    # Query model to get action
-                    action = gr00t_policy.get_action(
+                    # Query the model once, then execute several actions from the predicted chunk.
+                    action_chunk = gr00t_policy.get_action_chunk(
                         obs,
                         task.language,
                     )
 
-                    # Execute action in environment
-                    obs, reward, done, info = env.step(action.tolist())
+                    remaining_steps = max_steps + cfg.num_steps_wait - t
+                    steps_to_execute = min(
+                        cfg.action_horizon, len(action_chunk), remaining_steps
+                    )
+                    for action in action_chunk[:steps_to_execute]:
+                        # Record one pre-action frame for every environment step.
+                        img, wrist_img = get_libero_image(obs)
+                        top_view.append(img)
+                        wrist_view.append(wrist_img)
+
+                        obs, reward, done, info = env.step(action.tolist())
+                        t += 1
+                        if done:
+                            task_successes += 1
+                            total_successes += 1
+                            break
+
                     if done:
-                        task_successes += 1
-                        total_successes += 1
                         break
-                    t += 1
 
                 except Exception as e:
                     print(f"Caught exception: {e}")


### PR DESCRIPTION
## Summary

Fix the N1.5 LIBERO evaluator so it executes multiple actions from each predicted action chunk instead of discarding every prediction except timestep 0. Update the documented results for the four released checkpoints that were re-evaluated with the corrected control loop.

## Root cause

`ExternalRobotInferenceClient.get_action()` returns an action chunk, but the evaluator always called `_convert_to_libero_action(action_chunk, 0)`. It therefore re-queried the policy after every environment step and never executed the remaining predicted actions. This does not match the chunked control behavior used by the policy and substantially reduces the released checkpoints' evaluation performance.

## Changes

- Add an `action_horizon` evaluation option (default: 8).
- Convert the complete predicted chunk into LIBERO actions while keeping `get_action()` backward compatible.
- Execute up to `action_horizon` actions per policy query.
- Bound chunk execution by the episode step limit and stop immediately on success.
- Preserve one rollout video frame per environment step.
- Record the action horizon in the evaluation log.
- Update the README results and reproduction command for the four re-evaluated suites; keep the original LIBERO-90 result unchanged.

## Evaluation

The four released N1.5 LIBERO checkpoints were evaluated with `action_horizon=8`, 10 tasks per suite, and 10 trials per task (400 rollouts total):

| Suite | Successes | Success rate |
| --- | ---: | ---: |
| LIBERO-Spatial | 98/100 | 98% |
| LIBERO-Object | 99/100 | 99% |
| LIBERO-Goal | 94/100 | 94% |
| LIBERO-10 | 88/100 | 88% |
| **Overall** | **379/400** | **94.75%** |

<details>
<summary>Per-task success rates</summary>

### LIBERO-Spatial

| Task | Success rate |
| --- | ---: |
| black bowl between plate and ramekin | 100% |
| black bowl next to ramekin | 100% |
| black bowl from table center | 100% |
| black bowl on cookie box | 100% |
| black bowl in top drawer | 100% |
| black bowl on ramekin | 100% |
| black bowl next to cookie box | 100% |
| black bowl on stove | 90% |
| black bowl next to plate | 90% |
| black bowl on wooden cabinet | 100% |

### LIBERO-Object

| Task | Success rate |
| --- | ---: |
| alphabet soup | 100% |
| cream cheese | 100% |
| salad dressing | 100% |
| BBQ sauce | 90% |
| ketchup | 100% |
| tomato sauce | 100% |
| butter | 100% |
| milk | 100% |
| chocolate pudding | 100% |
| orange juice | 100% |

### LIBERO-Goal

| Task | Success rate |
| --- | ---: |
| open middle drawer | 100% |
| bowl on stove | 100% |
| wine bottle on cabinet | 100% |
| open top drawer and put bowl inside | 100% |
| bowl on cabinet | 80% |
| push plate in front of stove | 100% |
| cream cheese in bowl | 90% |
| turn on stove | 100% |
| bowl on plate | 100% |
| wine bottle on rack | 70% |

### LIBERO-10

| Task | Success rate |
| --- | ---: |
| alphabet soup and tomato sauce in basket | 100% |
| cream cheese and butter in basket | 100% |
| turn on stove and put moka pot on it | 90% |
| black bowl in bottom drawer and close it | 100% |
| two mugs on separate plates | 70% |
| book in back compartment of caddy | 100% |
| white mug on plate and pudding to its right | 90% |
| alphabet soup and cream cheese in basket | 80% |
| both moka pots on stove | 70% |
| mug in microwave and close it | 80% |

</details>

Generated logs and rollout videos are intentionally not included in this PR.

## Checks

- `git diff --check`
- `python -m py_compile examples/Libero/eval/run_libero_eval.py`
- Action-chunk conversion smoke test covering a three-timestep prediction and gripper normalization
- Full four-suite evaluation summarized above
