### PR TITLE
Replace deprecated torch.backends.cuda.sdp_kernel with torch.nn.attention.sdpa_kernel

### DIFF
--- a/gr00t/model/modules/dit.py
+++ b/gr00t/model/modules/dit.py
@@ -23,6 +23,7 @@ from diffusers.models.attention import Attention, FeedForward
 from diffusers.models.embeddings import SinusoidalPositionalEmbedding, TimestepEmbedding, Timesteps
 import torch
 from torch import nn
+from torch.nn.attention import SDPBackend, sdpa_kernel
 import torch.nn.functional as F
 
 
@@ -50,12 +51,7 @@ def _sdpa_context():
     if not _should_force_math_sdpa():
         return nullcontext()
 
-    return torch.backends.cuda.sdp_kernel(
-        enable_flash=False,
-        enable_math=True,
-        enable_mem_efficient=False,
-        enable_cudnn=False,
-    )
+    return sdpa_kernel([SDPBackend.MATH])
 
 
 class TimestepEncoder(nn.Module):

--- a/tests/gr00t/model/test_dit_sdpa_context.py
+++ b/tests/gr00t/model/test_dit_sdpa_context.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the DiT SDPA backend-selection context.
+
+``_sdpa_context`` pins scaled-dot-product attention to the math backend on DGX
+Spark (sm121), where the mem-efficient kernel dispatch is unreliable. It used to
+do that via ``torch.backends.cuda.sdp_kernel(...)``, which carries a
+``FutureWarning`` and is documented as slated for removal; it now uses
+``torch.nn.attention.sdpa_kernel([SDPBackend.MATH])``.
+
+The two are equivalent by construction -- the deprecated helper is a shim that
+builds its backend list from exactly these flags -- so these tests lock in the
+*observable* contract rather than re-deriving it:
+
+1. the four backend flags inside the context (the legacy call produced exactly
+   ``flash=False, mem_efficient=False, math=True, cudnn=False``),
+2. no deprecation warning escapes, which is the regression this guards,
+3. prior flag state is restored on exit, and
+4. the platform/env gating that decides whether to pin at all is unchanged.
+
+No GPU and no checkpoint download are required: backend selection is global
+state that PyTorch tracks on CPU-only builds too.
+"""
+
+import warnings
+
+from gr00t.model.modules.dit import _is_spark_sm121, _sdpa_context, _should_force_math_sdpa
+import pytest
+import torch
+
+
+# Flag state the legacy ``sdp_kernel(enable_flash=False, enable_math=True,
+# enable_mem_efficient=False, enable_cudnn=False)`` call produced.
+EXPECTED_MATH_ONLY = {"flash": False, "mem_efficient": False, "math": True, "cudnn": False}
+
+
+def _sdpa_flags() -> dict[str, bool]:
+    return {
+        "flash": torch.backends.cuda.flash_sdp_enabled(),
+        "mem_efficient": torch.backends.cuda.mem_efficient_sdp_enabled(),
+        "math": torch.backends.cuda.math_sdp_enabled(),
+        "cudnn": torch.backends.cuda.cudnn_sdp_enabled(),
+    }
+
+
+def test_forced_math_selects_math_backend_only(monkeypatch):
+    """Inside the pinned context, math is the only enabled SDPA backend."""
+    monkeypatch.setenv("GR00T_DIT_SDPA_MODE", "math")
+
+    with _sdpa_context():
+        assert _sdpa_flags() == EXPECTED_MATH_ONLY
+
+
+def test_forced_math_emits_no_deprecation_warning(monkeypatch):
+    """The pinned path must not raise FutureWarning/DeprecationWarning.
+
+    This is the regression guard: ``torch.backends.cuda.sdp_kernel`` warns and is
+    slated for removal, which would break the Spark path outright.
+    """
+    monkeypatch.setenv("GR00T_DIT_SDPA_MODE", "math")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        with _sdpa_context():
+            pass
+
+
+def test_forced_math_restores_previous_flags(monkeypatch):
+    """Exiting the context leaves global backend selection as it was."""
+    monkeypatch.setenv("GR00T_DIT_SDPA_MODE", "math")
+
+    before = _sdpa_flags()
+    with _sdpa_context():
+        pass
+    assert _sdpa_flags() == before
+
+
+def test_default_mode_does_not_touch_backend_selection(monkeypatch):
+    """Off the Spark path the context is inert -- no global flags are changed."""
+    monkeypatch.setenv("GR00T_DIT_SDPA_MODE", "default")
+
+    before = _sdpa_flags()
+    with _sdpa_context():
+        assert _sdpa_flags() == before
+    assert _sdpa_flags() == before
+
+
+@pytest.mark.parametrize(
+    "override,is_spark,expected",
+    [
+        ("math", False, True),  # explicit opt-in wins on any device
+        ("default", True, False),  # explicit opt-out wins even on Spark
+        (None, True, True),  # unset -> pin on Spark
+        (None, False, False),  # unset -> inert elsewhere
+    ],
+)
+def test_gating_precedence(monkeypatch, override, is_spark, expected):
+    """Env override takes precedence over the sm121 capability probe."""
+    monkeypatch.delenv("GR00T_DIT_SDPA_MODE", raising=False)
+    if override is not None:
+        monkeypatch.setenv("GR00T_DIT_SDPA_MODE", override)
+    monkeypatch.setattr("gr00t.model.modules.dit._is_spark_sm121", lambda: is_spark)
+
+    assert _should_force_math_sdpa() is expected
+
+
+def test_capability_probe_is_false_without_cuda():
+    """The probe must not raise on CPU-only builds."""
+    if torch.cuda.is_available():
+        pytest.skip("CUDA present; CPU-only branch not exercised")
+    assert _is_spark_sm121() is False


### PR DESCRIPTION
## What

`_sdpa_context()` in `gr00t/model/modules/dit.py` now uses
`torch.nn.attention.sdpa_kernel([SDPBackend.MATH])` instead of
`torch.backends.cuda.sdp_kernel(enable_flash=False, enable_math=True, enable_mem_efficient=False, enable_cudnn=False)`.

Net change to the module is +2/-6 lines.

## Why

`torch.backends.cuda.sdp_kernel` is deprecated. On the pinned `torch==2.9.0` it is
decorated with:

> `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context
> manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the
> new context manager, with updated signature.

raised as a `FutureWarning`. Two consequences:

1. **It is a latent break of the DGX Spark path.** `_sdpa_context` exists to pin
   SDPA to the math backend on sm121, where mem-efficient kernel dispatch is
   unreliable. When the deprecated context manager is removed, that workaround
   raises `AttributeError` and Spark inference breaks outright.
2. It sits in the hot path — the context is entered once per DiT block per
   denoising step, so the warning machinery runs on every attention call on that
   platform.

## Equivalence

This is not a judgement call; the deprecated function is a shim over the new one.
Its body builds a backend list from exactly these flags:

```python
backend_list = []
if enable_flash:          backend_list.append(SDPBackend.FLASH_ATTENTION)
if enable_mem_efficient:  backend_list.append(SDPBackend.EFFICIENT_ATTENTION)
if enable_math:           backend_list.append(SDPBackend.MATH)
if enable_cudnn:          backend_list.append(SDPBackend.CUDNN_ATTENTION)
with sdpa_kernel(backend_list) as context: ...
```

so the old call is `sdpa_kernel([SDPBackend.MATH])` by construction.

Confirmed by measurement on **both** pinned versions — `torch==2.9.0` (root
`pyproject.toml`) and `torch==2.10.0` (the Orin / Thor / DGX Spark deployment
pins). Identical backend flag state, warning gone:

| context | flash | mem_efficient | math | cudnn | warnings |
|---|---|---|---|---|---|
| `sdp_kernel(flash=F, math=T, mem=F, cudnn=F)` | False | False | True | False | `FutureWarning` |
| `sdpa_kernel([MATH])` | False | False | True | False | none |

Both restore the previous flag state on exit.

To be precise about urgency: `sdp_kernel` is **not** removed as of 2.10.0 — it
still exists and still warns. So this is not a live outage, it is removing a
dependency on an API that upstream says is going away, on the one code path that
DGX Spark inference depends on. `torch.nn.attention` has been available since
torch 2.3, so it is safe on every platform pin in this repo.

## Tests

New CPU-only `tests/gr00t/model/test_dit_sdpa_context.py` (9 tests) covering the
observable contract:

- math is the only enabled backend inside the pinned context
- **no `FutureWarning`/`DeprecationWarning` escapes** — the regression guard
- prior flag state is restored on exit
- the context is inert off the Spark path (no global flags touched)
- `GR00T_DIT_SDPA_MODE` override precedence over the sm121 probe is unchanged
- the capability probe does not raise on CPU-only builds

Against the pre-change implementation the warning test fails and the other 8
pass, which is the intended split: the 8 assert the contract that had to be
preserved, and the 1 is the defect.

No GPU or checkpoint download required: SDPA backend selection is global state
PyTorch tracks on CPU-only builds too.

Additionally verified on an RTX 5090 (`torch 2.9.0+cu128`, cc 12.0) that with a
CUDA device present the backend flag state is identical to the CPU-only
expectation above, and that a `BasicTransformerBlock` forward at production
dimensions (32 heads x 48, cross-attention 2048) is **bitwise identical** under
the old and new contexts:

| dtype | max_abs_diff | bitwise identical |
|---|---|---|
| `bfloat16` | 0.000e+00 | yes |
| `float32`  | 0.000e+00 | yes |
