### PR TITLE
Project cross-attention K/V once per inference instead of once per denoising step

### DIFF
--- a/gr00t/model/gr00t_n1d7/gr00t_n1d7.py
+++ b/gr00t/model/gr00t_n1d7/gr00t_n1d7.py
@@ -25,7 +25,7 @@ from transformers.feature_extraction_utils import BatchFeature
 import tree
 
 from gr00t.configs.model.gr00t_n1d7 import Gr00tN1d7Config
-from gr00t.model.modules.dit import AlternateVLDiT, DiT, SelfAttentionTransformer
+from gr00t.model.modules.dit import AlternateVLDiT, CrossAttnKVCache, DiT, SelfAttentionTransformer
 from gr00t.model.modules.embodiment_conditioned_mlp import (
     CategorySpecificMLP,
     MultiEmbodimentActionEncoder,
@@ -393,6 +393,12 @@ class Gr00tN1d7ActionHead(nn.Module):
                 :,
             ] = ramp[None, :, None].to(device)
 
+        # Cross-attention K/V depend only on vl_embeds, which is fixed for this call,
+        # so project them once and reuse across the denoising steps. Deliberately a
+        # local: vl_embeds changes every control step, so a cache that outlived this
+        # function would feed stale vision to the action head.
+        cross_kv_cache = CrossAttnKVCache() if self.config.use_alternate_vl_dit else None
+
         # Run denoising steps.
         for t in range(self.num_inference_timesteps):
             t_cont = t / float(self.num_inference_timesteps)  # e.g. goes 0, 1/N, 2/N, ...
@@ -420,6 +426,7 @@ class Gr00tN1d7ActionHead(nn.Module):
                     timestep=timesteps_tensor,
                     image_mask=backbone_output.image_mask,
                     backbone_attention_mask=backbone_output.backbone_attention_mask,
+                    kv_cache=cross_kv_cache,
                 )
             else:
                 model_output = self.model(

--- a/gr00t/model/modules/dit.py
+++ b/gr00t/model/modules/dit.py
@@ -44,6 +44,113 @@ def _should_force_math_sdpa() -> bool:
     return _is_spark_sm121()
 
 
+class CrossAttnKVCache(dict):
+    """Per-layer cross-attention K/V projections, valid for one denoising loop.
+
+    In the flow-matching loop the action tokens change every timestep but
+    ``encoder_hidden_states`` (the backbone's vision-language embedding) does not,
+    so ``to_k``/``to_v`` recompute identical tensors on every step. Caching them
+    removes those projections for all steps after the first.
+
+    **Lifetime is one inference call.** ``encoder_hidden_states`` changes on every
+    control step, so an instance must never be stored on a module or reused across
+    ``get_action`` calls -- that would feed stale vision to the action head. Build
+    it as a local inside the denoising loop and let it die with the call.
+    """
+
+
+class CachedCrossAttnProcessor:
+    """``AttnProcessor2_0`` that can reuse cross-attention K/V from a cache.
+
+    Mirrors diffusers' reference processor; the only change is that the ``to_k`` /
+    ``to_v`` projections (and the ``norm_k`` that follows them) are looked up in
+    ``kv_cache`` when one is supplied. With ``kv_cache=None`` -- the default
+    everywhere -- this is the stock path, which
+    ``test_processor_matches_diffusers_reference`` pins bitwise.
+    """
+
+    def __call__(
+        self,
+        attn,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+        kv_cache: Optional[dict] = None,
+        cache_key: Optional[int] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(
+                attention_mask, sequence_length, batch_size
+            )
+            attention_mask = attention_mask.view(
+                batch_size, attn.heads, -1, attention_mask.shape[-1]
+            )
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        # Only cross-attention is cacheable: for self-attention the source is
+        # hidden_states, which changes on every denoising step.
+        cacheable = (
+            kv_cache is not None and encoder_hidden_states is not None and cache_key is not None
+        )
+        cached = kv_cache.get(cache_key) if cacheable else None
+
+        if cached is None:
+            source = hidden_states if encoder_hidden_states is None else encoder_hidden_states
+            if encoder_hidden_states is not None and attn.norm_cross:
+                source = attn.norm_encoder_hidden_states(source)
+            key = attn.to_k(source)
+            value = attn.to_v(source)
+            head_dim = key.shape[-1] // attn.heads
+            key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+            value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+            if attn.norm_k is not None:
+                key = attn.norm_k(key)
+            if cacheable:
+                kv_cache[cache_key] = (key, value)
+        else:
+            key, value = cached
+            head_dim = key.shape[-1]
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(
+                batch_size, channel, height, width
+            )
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+        return hidden_states / attn.rescale_output_factor
+
+
 def _sdpa_context():
     # Spark (sm121) currently hits noisy/broken PyTorch mem-efficient SDPA kernel dispatch.
     # Force the safe math backend there; on every other platform this returns a no-op context.
@@ -177,6 +284,10 @@ class BasicTransformerBlock(nn.Module):
         else:
             self.final_dropout = None
 
+        # Accepts an optional kv_cache; with none supplied it is the stock
+        # AttnProcessor2_0 path, bitwise.
+        self.attn1.set_processor(CachedCrossAttnProcessor())
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -184,6 +295,8 @@ class BasicTransformerBlock(nn.Module):
         encoder_hidden_states: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         temb: Optional[torch.LongTensor] = None,
+        kv_cache: Optional[dict] = None,
+        cache_key: Optional[int] = None,
     ) -> torch.Tensor:
         # 0. Self-Attention
         if self.norm_type == "ada_norm":
@@ -201,6 +314,7 @@ class BasicTransformerBlock(nn.Module):
                 attention_mask=(
                     encoder_attention_mask if encoder_hidden_states is not None else attention_mask
                 ),
+                **({"kv_cache": kv_cache, "cache_key": cache_key} if kv_cache is not None else {}),
             )
         if self.final_dropout:
             attn_output = self.final_dropout(attn_output)
@@ -355,6 +469,7 @@ class AlternateVLDiT(DiT):
         return_all_hidden_states: bool = False,
         image_mask: Optional[torch.Tensor] = None,
         backbone_attention_mask: Optional[torch.Tensor] = None,
+        kv_cache: Optional[dict] = None,
     ):
         assert image_mask is not None, "Image mask is required"
 
@@ -401,6 +516,8 @@ class AlternateVLDiT(DiT):
                     encoder_hidden_states=encoder_hidden_states,
                     encoder_attention_mask=curr_encoder_attention_mask,
                     temb=temb,
+                    kv_cache=kv_cache,
+                    cache_key=idx,
                 )
             all_hidden_states.append(hidden_states)
 

--- a/tests/gr00t/model/test_cross_attn_kv_cache.py
+++ b/tests/gr00t/model/test_cross_attn_kv_cache.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-attention K/V are projected once per inference, not once per denoising step.
+
+``encoder_hidden_states`` (the backbone's vision-language embedding) is fixed for
+the whole flow-matching loop, so ``to_k``/``to_v`` recompute identical tensors on
+every timestep. ``CrossAttnKVCache`` projects them once and reuses them.
+
+This is a memory-traffic optimisation aimed at bandwidth-bound edge targets
+(Orin/Thor/Spark), where weight streaming dominates. On a discrete GPU the model
+sits far above its bandwidth floor and the saving is invisible, so these tests
+assert **bytes and call counts**, which are device-independent, rather than wall
+time. All CPU-only.
+
+The safety property that distinguishes this from the backbone-caching dead end is
+lifetime: the cache is a local inside ``get_action_with_features`` and dies with
+the call, so it can never pair fresh proprioception with stale vision.
+"""
+
+import pytest
+import torch
+
+
+diffusers = pytest.importorskip("diffusers")
+
+from diffusers.models.attention_processor import AttnProcessor2_0  # noqa: E402
+from gr00t.model.modules.dit import (  # noqa: E402
+    AlternateVLDiT,
+    BasicTransformerBlock,
+    CachedCrossAttnProcessor,
+    CrossAttnKVCache,
+)
+
+
+INNER, HEADS, HEAD_DIM, XDIM, LAYERS = 128, 4, 32, 96, 4
+CTX_TOKENS, ACT_TOKENS, BATCH = 11, 7, 2
+
+
+def _block(cross: bool = True) -> BasicTransformerBlock:
+    torch.manual_seed(0)
+    return BasicTransformerBlock(
+        INNER,
+        HEADS,
+        HEAD_DIM,
+        cross_attention_dim=XDIM if cross else None,
+        norm_type="ada_norm",
+        activation_fn="gelu-approximate",
+        attention_bias=True,
+        dropout=0.0,
+        final_dropout=False,
+    ).eval()
+
+
+def _inputs():
+    torch.manual_seed(1)
+    return (
+        torch.randn(BATCH, ACT_TOKENS, INNER),
+        torch.randn(BATCH, CTX_TOKENS, XDIM),
+        torch.randn(BATCH, INNER),
+    )
+
+
+def _count_projections(module):
+    """Count to_k / to_v invocations across every attention in ``module``."""
+    counts = {"to_k": 0, "to_v": 0}
+    handles = []
+    for name, sub in module.named_modules():
+        leaf = name.rsplit(".", 1)[-1]
+        if leaf in ("to_k", "to_v"):
+            handles.append(
+                sub.register_forward_hook(
+                    lambda _m, _i, _o, k=leaf: counts.__setitem__(k, counts[k] + 1)
+                )
+            )
+    return counts, handles
+
+
+def test_processor_matches_diffusers_reference():
+    """With no cache the processor must be bitwise identical to AttnProcessor2_0.
+
+    Guards against drift from the diffusers implementation this mirrors.
+    """
+    block = _block()
+    hidden, ctx, temb = _inputs()
+
+    block.attn1.set_processor(AttnProcessor2_0())
+    with torch.no_grad():
+        reference = block(hidden, encoder_hidden_states=ctx, temb=temb)
+
+    block.attn1.set_processor(CachedCrossAttnProcessor())
+    with torch.no_grad():
+        ours = block(hidden, encoder_hidden_states=ctx, temb=temb)
+
+    assert torch.equal(reference, ours)
+
+
+def test_cached_output_is_bitwise_identical():
+    """Reusing cached K/V must not change the block output at all."""
+    block = _block()
+    hidden, ctx, temb = _inputs()
+
+    with torch.no_grad():
+        uncached = block(hidden, encoder_hidden_states=ctx, temb=temb)
+
+    cache = CrossAttnKVCache()
+    with torch.no_grad():
+        first = block(hidden, encoder_hidden_states=ctx, temb=temb, kv_cache=cache, cache_key=0)
+        second = block(hidden, encoder_hidden_states=ctx, temb=temb, kv_cache=cache, cache_key=0)
+
+    assert torch.equal(uncached, first), "cache-populating pass diverged"
+    assert torch.equal(uncached, second), "cache-hit pass diverged"
+
+
+def test_cache_populates_once_and_is_reused():
+    """A second call with the same key must not re-run to_k / to_v."""
+    block = _block()
+    hidden, ctx, temb = _inputs()
+    cache = CrossAttnKVCache()
+    counts, handles = _count_projections(block)
+    try:
+        with torch.no_grad():
+            for _ in range(4):  # four denoising steps
+                block(hidden, encoder_hidden_states=ctx, temb=temb, kv_cache=cache, cache_key=0)
+    finally:
+        for h in handles:
+            h.remove()
+
+    assert counts == {"to_k": 1, "to_v": 1}, f"expected one projection each, got {counts}"
+    assert set(cache) == {0}
+
+
+def test_self_attention_is_never_cached():
+    """Self-attention K/V come from hidden_states, which changes every step."""
+    block = _block(cross=False)
+    hidden, _, temb = _inputs()
+    cache = CrossAttnKVCache()
+    counts, handles = _count_projections(block)
+    try:
+        with torch.no_grad():
+            for _ in range(3):
+                block(hidden, encoder_hidden_states=None, temb=temb, kv_cache=cache, cache_key=0)
+    finally:
+        for h in handles:
+            h.remove()
+
+    assert counts == {"to_k": 3, "to_v": 3}, f"self-attention must not be cached, got {counts}"
+    assert len(cache) == 0
+
+
+def test_full_dit_saves_projections_across_denoising_steps():
+    """End-to-end over AlternateVLDiT: cross-attn projections drop from 4x to 1x."""
+    torch.manual_seed(0)
+    dit = AlternateVLDiT(
+        num_attention_heads=HEADS,
+        attention_head_dim=HEAD_DIM,
+        num_layers=LAYERS,
+        output_dim=INNER,
+        cross_attention_dim=XDIM,
+        interleave_self_attention=True,
+        positional_embeddings=None,
+        dropout=0.0,
+        final_dropout=False,
+        norm_type="ada_norm",
+    ).eval()
+
+    torch.manual_seed(2)
+    hidden = torch.randn(BATCH, ACT_TOKENS, dit.inner_dim)
+    ctx = torch.randn(BATCH, CTX_TOKENS, XDIM)
+    timestep = torch.zeros(BATCH, dtype=torch.long)
+    image_mask = torch.zeros(BATCH, CTX_TOKENS, dtype=torch.bool)
+    image_mask[:, : CTX_TOKENS // 2] = True
+    attn_mask = torch.ones(BATCH, CTX_TOKENS, dtype=torch.bool)
+    kwargs = dict(
+        encoder_hidden_states=ctx,
+        timestep=timestep,
+        image_mask=image_mask,
+        backbone_attention_mask=attn_mask,
+    )
+
+    steps = 4
+    base_counts, handles = _count_projections(dit)
+    try:
+        with torch.no_grad():
+            baseline = [dit(hidden, **kwargs) for _ in range(steps)]
+    finally:
+        for h in handles:
+            h.remove()
+
+    counts, handles = _count_projections(dit)
+    cache = CrossAttnKVCache()
+    try:
+        with torch.no_grad():
+            cached = [dit(hidden, kv_cache=cache, **kwargs) for _ in range(steps)]
+    finally:
+        for h in handles:
+            h.remove()
+
+    for i, (a, b) in enumerate(zip(baseline, cached)):
+        assert torch.equal(a, b), f"denoising step {i} diverged with the cache"
+
+    # Self-attention layers still project every step (their source changes); only
+    # the cross-attention layers collapse to a single projection.
+    cross_layers = LAYERS // 2
+    saved = (steps - 1) * cross_layers
+    for proj in ("to_k", "to_v"):
+        assert base_counts[proj] == steps * LAYERS, (
+            f"baseline {proj} should be one per layer per step, got {base_counts[proj]}"
+        )
+        assert counts[proj] == base_counts[proj] - saved, (
+            f"{proj}: expected {base_counts[proj]} - {saved}, got {counts[proj]}"
+        )
+    assert len(cache) == cross_layers
+
+
+def test_cache_is_not_shared_across_inferences():
+    """A fresh cache must re-project: stale vision would be a correctness bug.
+
+    Mirrors the real call structure, where the cache is a local in
+    ``get_action_with_features`` and cannot outlive one inference.
+    """
+    block = _block()
+    hidden, ctx, temb = _inputs()
+
+    with torch.no_grad():
+        out_a = block(
+            hidden, encoder_hidden_states=ctx, temb=temb, kv_cache=CrossAttnKVCache(), cache_key=0
+        )
+
+    torch.manual_seed(99)
+    new_ctx = torch.randn(BATCH, CTX_TOKENS, XDIM)  # next control step: vision changed
+    with torch.no_grad():
+        out_b = block(
+            hidden,
+            encoder_hidden_states=new_ctx,
+            temb=temb,
+            kv_cache=CrossAttnKVCache(),
+            cache_key=0,
+        )
+        expected = block(hidden, encoder_hidden_states=new_ctx, temb=temb)
+
+    assert not torch.equal(out_a, out_b), "new vision must change the output"
+    assert torch.equal(expected, out_b), "fresh cache must match the uncached path"
+
+
+def test_denoising_loop_threads_the_cache_through():
+    """The real ``get_action_with_features`` loop must reuse K/V across timesteps.
+
+    The block-level tests above exercise ``dit.py`` directly and pass whether or
+    not the action head wires a cache in, so this is the test that pins the
+    integration.
+    """
+    from gr00t.configs.model.gr00t_n1d7 import Gr00tN1d7Config
+    from gr00t.model.gr00t_n1d7.gr00t_n1d7 import Gr00tN1d7ActionHead
+    from transformers.feature_extraction_utils import BatchFeature
+
+    steps, layers, seq = 4, 4, 8
+    config = Gr00tN1d7Config(
+        backbone_embedding_dim=64,
+        hidden_size=64,
+        input_embedding_dim=64,
+        max_state_dim=7,
+        max_action_dim=7,
+        action_horizon=4,
+        state_history_length=1,
+        num_inference_timesteps=steps,
+        max_num_embodiments=4,
+        add_pos_embed=True,
+        use_vlln=True,
+        max_seq_len=32,
+        use_alternate_vl_dit=True,
+        attend_text_every_n_blocks=2,
+        tune_projector=True,
+        tune_diffusion_model=True,
+        tune_vlln=True,
+        state_dropout_prob=0.0,
+        noise_beta_alpha=1.5,
+        noise_beta_beta=1.0,
+        noise_s=0.999,
+        num_timestep_buckets=1000,
+        attn_dropout=0.0,
+        diffusion_model_cfg={
+            "positional_embeddings": None,
+            "num_layers": layers,
+            "num_attention_heads": 2,
+            "attention_head_dim": 32,
+            "norm_type": "ada_norm",
+            "dropout": 0.0,
+            "final_dropout": False,
+            "output_dim": 64,
+            "interleave_self_attention": True,
+        },
+    )
+    torch.manual_seed(0)
+    head = Gr00tN1d7ActionHead(config).eval()
+
+    backbone_output = BatchFeature(
+        data={
+            "backbone_features": torch.randn(2, seq, config.backbone_embedding_dim),
+            # real backbone emits bool masks (attention_mask == 1)
+            "backbone_attention_mask": torch.ones(2, seq, dtype=torch.bool),
+            "image_mask": torch.ones(2, seq, dtype=torch.bool),
+        }
+    )
+    action_input = BatchFeature(
+        data={
+            "state": torch.randn(2, config.state_history_length, config.max_state_dim),
+            "embodiment_id": torch.zeros(2, dtype=torch.long),
+        }
+    )
+
+    counts, handles = _count_projections(head.model)
+    try:
+        with torch.no_grad():
+            torch.manual_seed(7)
+            head.get_action(backbone_output, action_input)
+    finally:
+        for h in handles:
+            h.remove()
+
+    cross_layers = layers // 2
+    # cross layers project once for the whole loop; self layers project every step
+    expected = cross_layers + cross_layers * steps
+    for proj in ("to_k", "to_v"):
+        assert counts[proj] == expected, (
+            f"{proj}: expected {expected} "
+            f"({cross_layers} cached cross + {cross_layers * steps} self), got {counts[proj]}"
+        )


### PR DESCRIPTION
## What

Cross-attention K/V in the action head are now projected **once per inference**
instead of once per denoising step.

`get_action_with_features` calls the DiT once per flow-matching timestep with the
same `encoder_hidden_states` (the backbone's vision-language embedding). Only the
action tokens change between steps, so `to_k`/`to_v` recompute identical tensors
every time. `CrossAttnKVCache` projects them once and reuses them.

## Why: memory traffic on bandwidth-bound targets

At production dimensions (16 layers, 8 cross-attending, `cross_attention_dim=2048`,
`inner_dim=1536`, `num_inference_timesteps=4`):

| | |
|---|---|
| projections avoided | **24 of 32** |
| weight traffic saved | **302 MB per inference** |
| share of total inference weight traffic | **~4.3%** |

I profiled the inference path's weight traffic at roughly 7 GB per forward. On a
discrete GPU that is irrelevant: measured time is ~63 ms against a ~3.9 ms bandwidth
floor, so the model runs ~16x above the roofline and removing bytes buys nothing.
It matters on the bandwidth-bound deployment targets, where the same 302 MB is
**~1.5 ms on Orin AGX** and **~1.1 ms on Thor/Spark**.

Because of that, the tests assert **projection counts and bytes**, which are
device-independent, rather than wall time. I did not measure a speedup and am not
claiming one.

## Scope limitation: this does not help the TensorRT path

`export_onnx_n1d7.py` exports the DiT as a single denoising step, and
`trt_model_forward.py` loops that engine `num_inference_timesteps` times, so the
engine recomputes the cross-attention projections internally on every step. The
ONNX export is unaffected by this change (`DiTWrapper` does not pass a cache, so it
traces the existing uncached path), but it gets no benefit either.

Getting the same saving under TRT would mean splitting the export into a one-shot
cross-K/V engine plus a per-step engine that consumes the cached tensors. Happy to
look at that separately if it is of interest.

## Correctness

Outputs are **bitwise identical** at every denoising step.

The cache is a local inside `get_action_with_features` and dies with the call.
`encoder_hidden_states` changes on every control step, so an instance that outlived
one inference would pair fresh proprioceptive state with stale vision. Making it a
local rules that out structurally rather than by convention, and a test pins it.
Self-attention is never cached, since its K/V come from the evolving hidden states.

`CachedCrossAttnProcessor` mirrors diffusers' `AttnProcessor2_0`; with no cache
supplied (the default everywhere, including training and export) it is the stock
path.

## Tests

`tests/gr00t/model/test_cross_attn_kv_cache.py`, 7 tests, CPU-only, no checkpoint:

- processor is bitwise identical to `AttnProcessor2_0` with no cache (catches drift
  from the implementation it mirrors)
- cached output bitwise identical to uncached, on both the populating and hit passes
- self-attention is never cached
- full `AlternateVLDiT`: all 4 steps bitwise identical, projections drop by exactly
  `(steps - 1) x cross_layers` against a measured baseline
- a fresh cache re-projects when vision changes
- the real `get_action` loop threads the cache: 16 -> 10 projections

The last one fails without the wiring in `gr00t_n1d7.py`; the block-level tests pass
either way by design, since they pin behaviour that must be preserved.

Full CPU suite: 674 passed, 8 skipped.
