### PR TITLE
Add: sparse video decoding for shard step indices

### DIFF
--- a/gr00t/configs/data/data_config.py
+++ b/gr00t/configs/data/data_config.py
@@ -92,6 +92,9 @@ class DataConfig:
     seed: int = 42
     multiprocessing_context: str = "fork"  # Options: "fork", "spawn", and "forkserver"
     allow_padding: bool = False
+    # When True, decode only the video frames needed by each shard instead of
+    # decoding every frame of an episode (speed up for video-heavy datasets).
+    use_faster_episode_loader: bool = False
 
     # Subsample ratio for the dataset
     subsample_ratio: float = 1.0

--- a/gr00t/data/dataset/factory.py
+++ b/gr00t/data/dataset/factory.py
@@ -66,6 +66,7 @@ class DatasetFactory:
                     episode_sampling_rate=self.config.data.episode_sampling_rate,
                     seed=self.config.data.seed,
                     allow_padding=self.config.data.allow_padding,
+                    use_faster_episode_loader=self.config.data.use_faster_episode_loader,
                 )
                 datasets.append(dataset)
             dataset_lengths = np.array([len(dataset) for dataset in datasets])

--- a/gr00t/data/dataset/lerobot_episode_loader_faster.py
+++ b/gr00t/data/dataset/lerobot_episode_loader_faster.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Faster LeRobot episode loader.
+
+This loader keeps the original episode loading behavior available through
+``__getitem__`` and adds a sparse video loading entrypoint through ``__call__``.
+The sparse path decodes only the video frames needed by the requested shard step
+indices while leaving the rest of the data loading pipeline unchanged.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .lerobot_episode_loader import LANG_KEYS, LeRobotEpisodeLoader
+
+
+class LeRobotEpisodeLoaderFaster(LeRobotEpisodeLoader):
+    """Episode loader that supports sparse video decoding for shard step indices."""
+
+    def _get_video_indices_from_steps(
+        self,
+        step_indices: np.ndarray,
+        video_delta_indices: list[int],
+        episode_length: int,
+        allow_padding: bool = False,
+    ) -> np.ndarray:
+        """
+        Convert shard step indices into the exact video frame indices to decode.
+
+        Args:
+            step_indices: Step indices assigned to the current shard for one episode
+            video_delta_indices: Temporal offsets configured for the video modality
+            episode_length: Actual episode length after parquet trimming
+            allow_padding: Whether to clamp frame indices into valid bounds
+
+        Returns:
+            Sorted unique frame indices needed by the requested steps
+        """
+        requested_indices = set()
+        for step_index in step_indices:
+            for delta_index in video_delta_indices:
+                frame_index = int(step_index + delta_index)
+                if allow_padding:
+                    frame_index = max(0, min(frame_index, episode_length - 1))
+                requested_indices.add(frame_index)
+        return np.array(sorted(requested_indices), dtype=int)
+
+    def __call__(
+        self,
+        idx: int,
+        step_indices: np.ndarray,
+        allow_padding: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Load one episode while decoding video only for the requested shard steps.
+
+        Args:
+            idx: Episode index to load
+            step_indices: Step indices assigned to the current shard for this episode
+            allow_padding: Whether to clamp temporal indices into valid bounds
+
+        Returns:
+            DataFrame with all non-video modalities loaded for the full episode and
+            video columns populated only at frame indices needed by ``step_indices``
+        """
+        if idx < 0 or idx >= len(self):
+            raise IndexError(f"Episode index {idx} out of bounds")
+
+        episode_meta = self.episodes_metadata[idx]
+        episode_id = episode_meta["episode_index"]
+        nominal_length = episode_meta["length"]
+
+        df = self._load_parquet_data(episode_id)
+
+        if "language" in self.modality_configs:
+            lang_key = self.modality_configs["language"].modality_keys[0]
+            if lang_key in LANG_KEYS:
+                new_languages = self.create_language_from_meta(episode_meta, len(df), lang_key)
+                df["language." + lang_key] = new_languages
+
+        actual_length = min(len(df), nominal_length)
+        df = df.iloc[:actual_length]
+
+        if "video" in self.modality_configs:
+            # [speed up] Decode only the sparse video frames needed by this shard.
+            video_indices = self._get_video_indices_from_steps(
+                np.asarray(step_indices, dtype=int),
+                self.modality_configs["video"].delta_indices,
+                actual_length,
+                allow_padding=allow_padding,
+            )
+            video_data = self._load_video_data(episode_id, video_indices)
+
+            for key in video_data.keys():
+                sparse_frames: list[Any | None] = [None] * len(df)
+                for frame_index, frame in zip(video_indices, video_data[key]):
+                    sparse_frames[int(frame_index)] = frame
+                df[f"video.{key}"] = sparse_frames
+
+        # [speed up] Keep mask loading unchanged to keep the optimization narrowly
+        # focused on the video decoding bottleneck.
+        mask_data = self._load_mask_data(episode_id, np.arange(actual_length))
+        for key in mask_data.keys():
+            assert len(mask_data[key]) == len(df), (
+                f"Mask data for {key} has length {len(mask_data[key])} but dataframe has length {len(df)}"
+            )
+            df[f"mask.{key}"] = [mask for mask in mask_data[key]]
+
+        return df

--- a/gr00t/data/dataset/sharded_single_step_dataset.py
+++ b/gr00t/data/dataset/sharded_single_step_dataset.py
@@ -22,6 +22,7 @@ from gr00t.data.interfaces import ShardedDataset
 from gr00t.data.types import EmbodimentTag, MessageType, ModalityConfig, VLAStepData
 
 from .lerobot_episode_loader import LeRobotEpisodeLoader
+from .lerobot_episode_loader_faster import LeRobotEpisodeLoaderFaster
 
 
 def extract_step_data(
@@ -108,6 +109,8 @@ class ShardedSingleStepDataset(ShardedDataset):
         episode_sampling_rate: Fraction of episode timesteps to use (for efficiency)
         seed: Random seed for reproducible sharding and sampling
         allow_padding: Whether to allow padding of indices to valid range [0, max_length - 1]
+        use_faster_episode_loader: Whether to enable sparse video loading based on
+            shard step indices
 
     Example:
         >>> dataset = ShardedSingleStepDataset(
@@ -135,6 +138,7 @@ class ShardedSingleStepDataset(ShardedDataset):
         episode_sampling_rate: float = 0.1,
         seed: int = 42,
         allow_padding: bool = False,
+        use_faster_episode_loader: bool = False,
     ):
         """Initialize single-step dataset with sharding configuration."""
         super().__init__(dataset_path)
@@ -144,12 +148,16 @@ class ShardedSingleStepDataset(ShardedDataset):
         self.episode_sampling_rate = episode_sampling_rate
         self.seed = seed
         self.allow_padding = allow_padding
+        self.use_faster_episode_loader = use_faster_episode_loader
         self.processor = None
         self.rng = np.random.default_rng(seed)
         action_delta_indices = modality_configs["action"].delta_indices
         self.action_horizon = max(action_delta_indices) - min(action_delta_indices) + 1
 
-        self.episode_loader = LeRobotEpisodeLoader(
+        episode_loader_cls = (
+            LeRobotEpisodeLoaderFaster if use_faster_episode_loader else LeRobotEpisodeLoader
+        )
+        self.episode_loader = episode_loader_cls(
             dataset_path=dataset_path,
             modality_configs=modality_configs,
         )
@@ -288,8 +296,16 @@ class ShardedSingleStepDataset(ShardedDataset):
         episodes = self.sharded_episodes[idx]
         datapoints = []
         for ep_idx, step_indices in episodes:
-            # Load episode data once per episode in shard
-            episode_data = self.episode_loader[ep_idx]
+            if self.use_faster_episode_loader:
+                # [speed up] Let the faster loader decode only the video frames
+                # needed by this shard's step indices for the current episode.
+                episode_data = self.episode_loader(
+                    ep_idx,
+                    step_indices,
+                    allow_padding=self.allow_padding,
+                )
+            else:
+                episode_data = self.episode_loader[ep_idx]
             for step_index in step_indices:
                 datapoints.append(self.get_datapoint(episode_data, step_index))
         return datapoints

--- a/tests/gr00t/data/test_lerobot_episode_loader_faster.py
+++ b/tests/gr00t/data/test_lerobot_episode_loader_faster.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test LeRobotEpisodeLoaderFaster (sparse video loading for shard step indices).
+
+The faster loader decodes only the video frames needed by the requested shard
+steps instead of every frame of an episode. Video decoding is mocked here so the
+tests run without a video backend; the assertions verify which frame indices
+the loader asks the decoder for and how the sparse frames are placed back into
+the episode DataFrame.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from gr00t.data.dataset.lerobot_episode_loader_faster import LeRobotEpisodeLoaderFaster
+from gr00t.data.types import ModalityConfig
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _make_fake_loader(
+    episode_lengths=(100, 50),
+    video_delta_indices=(-15, 0),
+):
+    """Build a LeRobotEpisodeLoaderFaster with mocked internals (no dataset on disk).
+
+    ``_load_video_data`` is a recording stub: it returns frame objects equal to
+    their position in the requested index array, and records the requested
+    indices on the returned loader under ``requested_video_indices``.
+    """
+    loader = LeRobotEpisodeLoaderFaster.__new__(LeRobotEpisodeLoaderFaster)
+    loader.episodes_metadata = [
+        {"episode_index": i, "length": n} for i, n in enumerate(episode_lengths)
+    ]
+    loader.modality_configs = {
+        "video": ModalityConfig(delta_indices=list(video_delta_indices), modality_keys=["cam"]),
+        "mask": ModalityConfig(delta_indices=[0], modality_keys=["seg"]),
+        "language": ModalityConfig(delta_indices=[0], modality_keys=["task"]),
+        "state": ModalityConfig(delta_indices=[0], modality_keys=["x"]),
+        "action": ModalityConfig(delta_indices=list(range(8)), modality_keys=["x"]),
+    }
+
+    def fake_parquet(episode_id):
+        n = episode_lengths[episode_id]
+        return pd.DataFrame({"observation.state": [np.zeros(6)] * n})
+
+    def fake_language(episode_meta, n, lang_key):
+        return [f"task_{episode_meta['episode_index']}"] * n
+
+    def fake_video(episode_id, indices):
+        loader.requested_video_indices.append(np.asarray(indices))
+        return {"cam": np.arange(len(indices))}
+
+    def fake_mask(episode_id, indices):
+        return {"seg": np.arange(len(indices))}
+
+    loader.requested_video_indices = []
+    loader._load_parquet_data = fake_parquet
+    loader.create_language_from_meta = fake_language
+    loader._load_video_data = fake_video
+    loader._load_mask_data = fake_mask
+    return loader
+
+
+class TestGetVideoIndicesFromSteps:
+    @pytest.mark.parametrize(
+        ("steps", "delta", "episode_length", "allow_padding", "expected"),
+        [
+            # In-bounds steps with a negative delta
+            (np.array([10, 11, 12]), [-15, 0], 100, False, [-5, -4, -3, 10, 11, 12]),
+            # allow_padding clamps out-of-range indices to [0, episode_length - 1]
+            (np.array([0, 1]), [-3, 0], 100, True, [0, 1]),
+            # Without padding, out-of-range indices are passed through
+            (np.array([0, 1]), [-3, 0], 100, False, [-3, -2, 0, 1]),
+            # Wide delta range (action horizon) spanning the whole episode
+            (np.array([50]), list(range(40)), 100, True, list(range(50, 90))),
+            # Duplicates from different steps are deduplicated
+            (np.array([5, 6]), [0, 1], 100, False, [5, 6, 7]),
+        ],
+    )
+    def test_index_computation(self, steps, delta, episode_length, allow_padding, expected):
+        loader = _make_fake_loader()
+        indices = loader._get_video_indices_from_steps(
+            steps, delta, episode_length, allow_padding=allow_padding
+        )
+        assert indices.tolist() == expected
+
+
+class TestCallSparseLoading:
+    def test_decodes_only_requested_frames(self):
+        loader = _make_fake_loader()
+        steps = np.array([10, 11, 12])
+        loader(0, steps, allow_padding=True)
+
+        # The decoder must be asked for exactly the union of step + delta
+        # indices (clamped), not the full episode range 0..99.
+        assert len(loader.requested_video_indices) == 1
+        requested = loader.requested_video_indices[0]
+        assert requested.tolist() == [0, 10, 11, 12]
+
+    def test_frames_placed_at_requested_positions_none_elsewhere(self):
+        loader = _make_fake_loader()
+        df = loader(0, np.array([10, 11, 12]), allow_padding=True)
+
+        assert len(df) == 100
+        col = df["video.cam"]
+        # Frame objects equal their position in the decoded batch; they must
+        # land exactly at the requested frame indices.
+        assert col.iloc[0] == 0
+        assert col.iloc[10] == 1
+        assert col.iloc[11] == 2
+        assert col.iloc[12] == 3
+        # All other positions must stay empty.
+        populated = {0, 10, 11, 12}
+        assert col.iloc[[i for i in range(100) if i not in populated]].isna().all()
+
+    def test_mask_still_fully_loaded(self):
+        loader = _make_fake_loader()
+        df = loader(0, np.array([10, 11, 12]), allow_padding=True)
+        assert df["mask.seg"].iloc[0] == 0
+        assert df["mask.seg"].iloc[99] == 99
+
+    def test_no_padding_keeps_negative_indices(self):
+        loader = _make_fake_loader()
+        loader(0, np.array([0, 1]), allow_padding=False)
+        requested = loader.requested_video_indices[-1]
+        assert requested.tolist() == [-15, -14, 0, 1]
+
+    def test_trims_to_nominal_length(self):
+        loader = _make_fake_loader()
+        df = loader(1, np.array([5]), allow_padding=True)
+        assert len(df) == 50
+
+    def test_out_of_bounds_raises(self):
+        loader = _make_fake_loader()
+        with pytest.raises(IndexError):
+            loader(99, np.array([0]))
+
+    def test_non_video_modalities_loaded_for_full_episode(self):
+        loader = _make_fake_loader()
+        df = loader(0, np.array([10]), allow_padding=True)
+        assert df["language.task"].iloc[0] == "task_0"
+        assert df["observation.state"].iloc[0].shape == (6,)
+
+
+class TestOriginalGetitemPreserved:
+    def test_getitem_still_loads_full_episode(self):
+        loader = _make_fake_loader()
+        df = loader[0]
+        assert len(df["video.cam"]) == 100
+        assert df["video.cam"].iloc[99] == 99  # fully populated, no None
+
+
+class TestDatasetWiring:
+    """ShardedSingleStepDataset picks the loader class based on the flag."""
+
+    MODALITY_CONFIGS = {
+        "video": ModalityConfig(delta_indices=[0], modality_keys=["cam"]),
+        "state": ModalityConfig(delta_indices=[0], modality_keys=["x"]),
+        "action": ModalityConfig(delta_indices=list(range(4)), modality_keys=["x"]),
+        "language": ModalityConfig(delta_indices=[0], modality_keys=["task"]),
+        "mask": ModalityConfig(delta_indices=[0], modality_keys=["seg"]),
+    }
+
+    def _episode_df(self, n):
+        """DataFrame with the columns extract_step_data expects."""
+        return pd.DataFrame(
+            {
+                "state.x": [np.zeros(1) for _ in range(n)],
+                "action.x": [np.zeros(1) for _ in range(n)],
+                "video.cam": [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(n)],
+                "mask.seg": [np.zeros((8, 8), dtype=np.uint8) for _ in range(n)],
+                "language.task": [f"task_{i}" for i in range(n)],
+            }
+        )
+
+    def _make_dataset(self, use_faster, faster_loader):
+        from gr00t.data.dataset.sharded_single_step_dataset import ShardedSingleStepDataset
+        from gr00t.data.embodiment_tags import EmbodimentTag
+
+        with patch(
+            "gr00t.data.dataset.sharded_single_step_dataset.LeRobotEpisodeLoader"
+        ) as MockLoader:
+            mock_loader = MagicMock()
+            mock_loader.episode_lengths = [50]
+            mock_loader.get_episode_length = lambda idx: 50
+            MockLoader.return_value = mock_loader
+
+            if use_faster:
+                with patch(
+                    "gr00t.data.dataset.sharded_single_step_dataset.LeRobotEpisodeLoaderFaster"
+                ) as MockFaster:
+                    MockFaster.return_value = faster_loader
+                    dataset = ShardedSingleStepDataset(
+                        dataset_path="/fake/dataset",
+                        embodiment_tag=EmbodimentTag.NEW_EMBODIMENT,
+                        modality_configs=self.MODALITY_CONFIGS,
+                        shard_size=1024,
+                        episode_sampling_rate=1.0,
+                        use_faster_episode_loader=True,
+                    )
+            else:
+                dataset = ShardedSingleStepDataset(
+                    dataset_path="/fake/dataset",
+                    embodiment_tag=EmbodimentTag.NEW_EMBODIMENT,
+                    modality_configs=self.MODALITY_CONFIGS,
+                    shard_size=1024,
+                    episode_sampling_rate=1.0,
+                )
+        return dataset
+
+    class _RecordingFasterLoader:
+        """Stand-in for LeRobotEpisodeLoaderFaster that records __call__ args."""
+
+        def __init__(self, episode_df):
+            self.episode_lengths = [50]
+            self._episode_df = episode_df
+            self.calls = []
+
+        def get_episode_length(self, episode_index):
+            return 50
+
+        def __call__(self, ep_idx, step_indices, allow_padding=False):
+            self.calls.append((ep_idx, np.asarray(step_indices), allow_padding))
+            return self._episode_df
+
+    def test_faster_loader_called_with_shard_steps(self):
+        # The faster loader's __call__ must receive the shard's step indices
+        # and the dataset's allow_padding setting. The loader returns the full
+        # episode (50 rows, as the real loader does); the dataset trims steps
+        # to the effective length (47 = 50 - 4 + 1).
+        faster_loader = self._RecordingFasterLoader(self._episode_df(50))
+        dataset = self._make_dataset(use_faster=True, faster_loader=faster_loader)
+        dataset.processor = lambda messages: messages[0]["content"]
+
+        dataset.get_shard(0)
+
+        assert len(faster_loader.calls) == 1
+        ep_idx, step_indices, allow_padding = faster_loader.calls[0]
+        assert ep_idx == 0
+        assert isinstance(step_indices, np.ndarray)
+        assert len(step_indices) == 47  # 50 steps - 4 action horizon + 1
+        assert allow_padding is False
+
+    def test_default_uses_original_loader(self):
+        # Default (flag off) must keep using the original __getitem__ path and
+        # never instantiate the faster loader class.
+        from gr00t.data.dataset.sharded_single_step_dataset import ShardedSingleStepDataset
+        from gr00t.data.embodiment_tags import EmbodimentTag
+
+        with (
+            patch(
+                "gr00t.data.dataset.sharded_single_step_dataset.LeRobotEpisodeLoader"
+            ) as MockLoader,
+            patch(
+                "gr00t.data.dataset.sharded_single_step_dataset.LeRobotEpisodeLoaderFaster"
+            ) as MockFaster,
+        ):
+            mock_loader = MagicMock()
+            mock_loader.episode_lengths = [50]
+            mock_loader.get_episode_length = lambda idx: 50
+            MockLoader.return_value = mock_loader
+
+            dataset = ShardedSingleStepDataset(
+                dataset_path="/fake/dataset",
+                embodiment_tag=EmbodimentTag.NEW_EMBODIMENT,
+                modality_configs=self.MODALITY_CONFIGS,
+                shard_size=1024,
+                episode_sampling_rate=1.0,
+            )
+
+        assert dataset.episode_loader is mock_loader
+        MockFaster.assert_not_called()


### PR DESCRIPTION
## Summary

`ShardedSingleStepDataset` loads each episode's **full video** for every shard that touches it. With episode sampling this means the same long video is decoded repeatedly (once per shard split), most of it unused.

This PR adds an opt-in faster loader (`LeRobotEpisodeLoaderFaster`) that decodes **only the video frames needed by the current shard's step indices**, via a new `use_faster_episode_loader` flag. When disabled (default), behavior is byte-identical to before.

## Changes

- `gr00t/data/dataset/lerobot_episode_loader_faster.py` (new): subclasses `LeRobotEpisodeLoader`; `__getitem__` behavior unchanged, adds `__call__(idx, step_indices, allow_padding)` which computes the exact video frame window per shard and decodes sparsely. Frames outside the window stay empty (`None`) in the episode DataFrame; parquet / language / mask loading is unchanged.
- `gr00t/data/dataset/sharded_single_step_dataset.py`: `use_faster_episode_loader` flag (default `False`), loader class selection, `get_shard` branch.
- `gr00t/configs/data/data_config.py` + `gr00t/data/dataset/factory.py`: config field and wiring.
- `tests/gr00t/data/test_lerobot_episode_loader_faster.py` (new): 15 tests for index computation, sparse frame placement, mask/language parity, and dataset wiring.

## Validation

- Output identical to the original loader: 128 datapoints of shard 0 compared frame-by-frame (video, state, action, text), 0 mismatches; shard partition identical under the same seed.
- Unit tests: 39/39 pass (CPU).

Benchmarked on a 3071-episode teleop dataset (176,864 frames, 64–94 frames/episode, shard_size=128, episode_sampling_rate=0.1):

| | original | faster |
|---|---|---|
| frames decoded (4 shards) | 1,768,640 | 130,799 (13.5x fewer) |
| `get_shard` time (4 shards × 3 runs) | 6.22 s | 3.39 s (~1.8x) |

Note: wall-clock speedup is smaller than the decode reduction because per-episode parquet/language overhead is paid per shard touch; speedup grows with episode length.