### PR TITLE
fix(config): isolate default modality configs

### DIFF
--- a/gr00t/configs/data/data_config.py
+++ b/gr00t/configs/data/data_config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from dataclasses import dataclass, field
 from typing import Annotated, Any, List, Optional
 
@@ -68,7 +69,7 @@ class DataConfig:
     # Supplied via code defaults / a `--load-config-path` YAML / the pretrained
     # checkpoint, not typed on the CLI, so it is hidden from tyro with Suppress.
     modality_configs: Annotated[dict[str, dict[str, ModalityConfig]], tyro.conf.Suppress] = field(
-        default_factory=lambda: MODALITY_CONFIGS
+        default_factory=lambda: copy.deepcopy(MODALITY_CONFIGS)
     )
 
     # Sharded dataset configuration

--- a/tests/gr00t/configs/test_data_config_isolation.py
+++ b/tests/gr00t/configs/test_data_config_isolation.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gr00t.configs.data.data_config import DataConfig
+from gr00t.configs.data.embodiment_configs import MODALITY_CONFIGS
+
+
+def test_default_modality_configs_are_deeply_isolated():
+    first = DataConfig()
+    second = DataConfig()
+
+    assert first.modality_configs is not second.modality_configs
+    assert first.modality_configs is not MODALITY_CONFIGS
+
+    embodiment = next(iter(MODALITY_CONFIGS))
+    modality = next(iter(MODALITY_CONFIGS[embodiment]))
+    global_config = MODALITY_CONFIGS[embodiment][modality]
+    original_delta_indices = list(global_config.delta_indices)
+
+    assert first.modality_configs[embodiment][modality] is not global_config
+    first.modality_configs[embodiment][modality].delta_indices.append(999_999)
+
+    assert second.modality_configs[embodiment][modality].delta_indices == original_delta_indices
+    assert MODALITY_CONFIGS[embodiment][modality].delta_indices == original_delta_indices


### PR DESCRIPTION
## Summary

`DataConfig.modality_configs` currently shares the module-level `MODALITY_CONFIGS` object across instances. `Config.validate()` mutates that tree, so validating one config can corrupt defaults used by later configs in the same process.

This change deep-copies the default modality configuration for each `DataConfig`.

## Tests

Adds a regression test proving nested mutations in one config do not affect another config or the global registry