### PR TITLE
fix(config): harden validation error paths

### DIFF
--- a/gr00t/configs/base_config.py
+++ b/gr00t/configs/base_config.py
@@ -175,7 +175,7 @@ class Config:
             # if not Path(d_cfg.dataset_path).exists():
             #     raise ValueError(f"Dataset path does not exist: {d_cfg.dataset_path}")
             if d_cfg.dataset_type == "physical_embodiment" and not d_cfg.embodiment_tag:
-                raise ValueError(f"Embodiment tag is empty for dataset {d_cfg.dataset_path}")
+                raise ValueError(f"Embodiment tag is empty for dataset {d_cfg.dataset_paths}")
             if d_cfg.embodiment_tag is not None:
                 embodiment_tags.add(d_cfg.embodiment_tag)
 
@@ -207,7 +207,8 @@ class Config:
                         type=ActionType.NON_EEF,
                         format=ActionFormat.DEFAULT,
                     )
-                ] * len(self.data.modality_configs[embodiment_tag]["action"].modality_keys)
+                    for _ in self.data.modality_configs[embodiment_tag]["action"].modality_keys
+                ]
 
         # Validate precision settings
         if self.training.fp16 and self.training.bf16:

--- a/tests/gr00t/configs/test_base_config_validation.py
+++ b/tests/gr00t/configs/test_base_config_validation.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from gr00t.configs.base_config import Config
+from gr00t.configs.data.data_config import SingleDatasetConfig
+from gr00t.data.types import ModalityConfig
+
+
+def test_missing_embodiment_tag_reports_dataset_paths():
+    cfg = Config()
+    cfg.data.datasets = [SingleDatasetConfig(dataset_paths=["dataset-a"], embodiment_tag=None)]
+
+    with pytest.raises(ValueError, match="dataset-a"):
+        cfg.validate()
+
+
+def test_default_action_configs_are_distinct_objects():
+    cfg = Config()
+    cfg.data.datasets = [SingleDatasetConfig(dataset_paths=["dataset-a"], embodiment_tag="test_robot")]
+    cfg.data.modality_configs = {
+        "test_robot": {
+            "action": ModalityConfig(delta_indices=[0], modality_keys=["arm", "gripper"]),
+        }
+    }
+
+    cfg.validate()
+
+    action_configs = cfg.data.modality_configs["test_robot"]["action"].action_configs
+    assert action_configs is not None
+    assert len(action_configs) == 2
+    assert action_configs[0] is not action_configs[1]
+
+    action_configs[0].state_key = "arm_state"
+    assert action_configs[1].state_key is None


### PR DESCRIPTION
## Summary

Fixes two deterministic config-validation defects:

- missing `embodiment_tag` errors referenced nonexistent `dataset_path` instead of `dataset_paths`, causing `AttributeError`;
- default `ActionConfig` entries were created with list multiplication, so all entries referenced the same mutable object.

## Tests

Adds regression coverage for both behaviors