### PR TITLE
fix(policy): honor replay action delta indices

### DIFF
--- a/gr00t/policy/replay_policy.py
+++ b/gr00t/policy/replay_policy.py
@@ -295,11 +295,7 @@ class ReplayPolicy(BasePolicy):
                 f"Action key '{action_key}' must be a numpy array of shape (B, T, D), got {action_arr.shape}"
             )
 
-            action_horizon = (
-                self.modality_configs["action"].delta_indices[-1]
-                - self.modality_configs["action"].delta_indices[0]
-                + 1
-            )
+            action_horizon = len(self.modality_configs["action"].delta_indices)
             assert action_arr.shape[1] == action_horizon, (
                 f"Action key '{action_key}'s horizon must be {action_horizon}. "
                 f"Got {action_arr.shape[1]}"
@@ -324,40 +320,28 @@ class ReplayPolicy(BasePolicy):
             first_video_key = self.modality_configs["video"].modality_keys[0]
             batch_size = observation["video"][first_video_key].shape[0]
         # If batch size is not provided in observation, check if it's provided in options
-        elif "batch_size" in options:
+        elif options is not None and "batch_size" in options:
             batch_size = options["batch_size"]
         else:
             batch_size = 1
             print("No batch size provided, using default batch size of 1")
-        # Note that this can differ form the execution horizon, as the policy can predict more steps than what's actually executed.
-        action_horizon = (
-            self.modality_configs["action"].delta_indices[-1]
-            - self.modality_configs["action"].delta_indices[0]
-            + 1
-        )
+
+        action_delta_indices = self.modality_configs["action"].delta_indices
+        action_horizon = len(action_delta_indices)
         assert self.execution_horizon <= action_horizon, (
             f"Execution horizon must be less than or equal to the model's action horizon. Got {self.execution_horizon} and {action_horizon}"
         )
 
-        # Extract action chunk starting from current step
+        if self.current_step >= self.episode_length:
+            action_indices = np.full(action_horizon, self.episode_length - 1, dtype=np.int64)
+        else:
+            action_indices = self.current_step + np.asarray(action_delta_indices, dtype=np.int64)
+            action_indices = np.clip(action_indices, 0, self.episode_length - 1)
+
+        # Extract the configured action offsets from the current step.
         action_chunk = {}
         for key, actions in self.actions.items():
-            if self.current_step >= self.episode_length:
-                # Past the end of episode: return last action repeated
-                chunk = np.tile(actions[-1:], (action_horizon, 1))  # (action_horizon, D)
-            else:
-                end_step = self.current_step + action_horizon
-                if end_step <= self.episode_length:
-                    # Normal case: extract without padding
-                    chunk = actions[self.current_step : end_step]  # (action_horizon, D)
-                else:
-                    # Near end of episode: pad with last action
-                    remaining = self.episode_length - self.current_step
-                    valid_chunk = actions[self.current_step :]  # (remaining, D)
-                    padding = np.tile(
-                        actions[-1:], (action_horizon - remaining, 1)
-                    )  # (action_horizon - remaining, D)
-                    chunk = np.concatenate([valid_chunk, padding], axis=0)
+            chunk = actions[action_indices]
 
             # Expand to batch dimension: (action_horizon, D) -> (B, action_horizon, D)
             action_chunk[key] = np.tile(chunk[np.newaxis, :, :], (batch_size, 1, 1))

--- a/tests/gr00t/policy/test_replay_policy.py
+++ b/tests/gr00t/policy/test_replay_policy.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from gr00t.data.types import ModalityConfig
+from gr00t.policy.replay_policy import ReplayPolicy
+
+
+def _make_policy_like(delta_indices, *, current_step=0):
+    return SimpleNamespace(
+        modality_configs={
+            "action": ModalityConfig(delta_indices=delta_indices, modality_keys=["arm"]),
+        },
+        execution_horizon=1,
+        current_step=current_step,
+        episode_length=6,
+        episode_index=0,
+        actions={"arm": np.arange(6, dtype=np.float32).reshape(6, 1)},
+    )
+
+
+def test_replay_policy_honors_non_contiguous_action_delta_indices():
+    policy = _make_policy_like([0, 2, 4])
+
+    action, _ = ReplayPolicy._get_action(policy, observation=None, options={"batch_size": 2})
+
+    np.testing.assert_array_equal(action["arm"][0, :, 0], np.array([0, 2, 4], dtype=np.float32))
+    np.testing.assert_array_equal(action["arm"][1], action["arm"][0])
+    ReplayPolicy.check_action(policy, action)
+
+
+def test_replay_policy_clips_configured_offsets_at_episode_end():
+    policy = _make_policy_like([0, 2, 4], current_step=4)
+
+    action, _ = ReplayPolicy._get_action(policy, observation=None, options={"batch_size": 1})
+
+    np.testing.assert_array_equal(action["arm"][0, :, 0], np.array([4, 5, 5], dtype=np.float32))
+
+
+def test_replay_policy_defaults_batch_size_when_options_are_omitted():
+    policy = _make_policy_like([0, 2, 4])
+
+    action, _ = ReplayPolicy._get_action(policy, observation=None, options=None)
+
+    assert action["arm"].shape == (1, 3, 1)


### PR DESCRIPTION
## Summary

`ReplayPolicy` assumed action `delta_indices` were contiguous by deriving the horizon from `last - first + 1` and slicing consecutive rows.

`ModalityConfig` permits arbitrary offsets, so valid configurations such as `[0, 2, 4]` were replayed incorrectly.

This change samples the configured offsets directly and clips them at episode boundaries.

## Tests

Covers non-contiguous offsets, end-of-episode clipping, and the `options=None` batch-size fallback